### PR TITLE
availibility, dashboard and results html update and schedule html introduce

### DIFF
--- a/availability.html
+++ b/availability.html
@@ -1,409 +1,448 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SmartMeet – Join Room</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --p1: #6d28d9; --p2: #7c3aed; --p3: #a78bfa; --p4: #ede9fe;
-      --pink: #f472b6; --cyan: #22d3ee; --green: #4ade80;
-      --bg: #f5f3ff; --card: #ffffff; --text: #1e1b4b; --muted: #6b7280;
-
-      /* tile states */
-      --tile-empty:  #f3f4f6;
-      --tile-free:   #bbf7d0;
-      --tile-maybe:  #fef08a;
-      --tile-busy:   #fecaca;
-      --tile-best:   #6d28d9;
-    }
-    * { box-sizing: border-box; }
-    body { font-family: 'Nunito', sans-serif; background: var(--bg); color: var(--text); margin: 0; }
-
-    /* Navbar */
-    .sm-navbar {
-      background: linear-gradient(90deg, #1e1b4b 0%, #4c1d95 60%, #6d28d9 100%);
-      padding: .6rem 0; box-shadow: 0 2px 16px rgba(109,40,217,.4);
-    }
-    .sm-navbar .navbar-brand {
-      font-family: 'Press Start 2P', monospace; font-size: .9rem;
-      color: #fff; letter-spacing: 1px;
-    }
-    .sm-navbar .navbar-brand span { color: var(--cyan); }
-    .sm-navbar .nav-link {
-      color: rgba(255,255,255,.8) !important; font-weight: 700; font-size: .85rem;
-      padding: 6px 14px !important; border-radius: 20px; transition: background .2s;
-    }
-    .sm-navbar .nav-link:hover, .sm-navbar .nav-link.active {
-      background: rgba(255,255,255,.15); color: #fff !important;
-    }
-    .btn-nav-pink {
-      background: var(--pink); color: #fff; border: none; border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 6px 16px; transition: transform .15s;
-    }
-    .btn-nav-pink:hover { transform: translateY(-2px); color: #fff; }
-    .btn-nav-outline {
-      background: transparent; color: #fff;
-      border: 2px solid rgba(255,255,255,.4); border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 5px 16px; transition: background .2s;
-    }
-    .btn-nav-outline:hover { background: rgba(255,255,255,.15); color: #fff; }
-
-    /* Room Banner */
-    .room-banner {
-      background: linear-gradient(135deg, #1e1b4b 0%, #4c1d95 50%, #7c3aed 100%);
-      color: #fff; padding: 40px 0 32px;
-      position: relative; overflow: hidden;
-    }
-    .room-banner::before {
-      content: '';
-      position: absolute; inset: 0;
-      background: radial-gradient(ellipse at 80% 50%, rgba(34,211,238,.12) 0%, transparent 60%),
-                  radial-gradient(ellipse at 10% 80%, rgba(244,114,182,.1) 0%, transparent 50%);
-    }
-    .room-badge {
-      display: inline-block;
-      background: rgba(255,255,255,.15); border: 1px solid rgba(255,255,255,.3);
-      border-radius: 20px; padding: 4px 16px;
-      font-size: .78rem; font-weight: 800; letter-spacing: .06em;
-      margin-bottom: 10px;
-    }
-    .pixel-sm { font-family: 'Press Start 2P', monospace; font-size: clamp(.8rem, 2vw, 1.1rem); line-height: 1.6; }
-
-    /* Participant avatars */
-    .part-avatar {
-      display: inline-flex; flex-direction: column; align-items: center; gap: 4px;
-    }
-    .part-circle {
-      width: 48px; height: 48px; border-radius: 50%;
-      display: flex; align-items: center; justify-content: center;
-      font-size: 1.4rem;
-      border: 3px solid rgba(255,255,255,.35);
-      transition: transform .2s;
-    }
-    .part-circle:hover { transform: scale(1.12); }
-    .part-name { font-size: .7rem; font-weight: 700; opacity: .9; }
-    .online-dot {
-      width: 10px; height: 10px; border-radius: 50%;
-      background: var(--green); border: 2px solid rgba(255,255,255,.4);
-      box-shadow: 0 0 5px var(--green);
-      display: inline-block;
-    }
-
-    /* Main layout card */
-    .room-card {
-      background: var(--card); border-radius: 24px;
-      box-shadow: 0 8px 40px rgba(109,40,217,.1);
-      border: 2px solid var(--p4);
-      overflow: hidden;
-    }
-    .room-card-header {
-      background: linear-gradient(90deg, var(--p4), #fce7f3);
-      padding: 14px 24px;
-      border-bottom: 2px solid #ede9fe;
-      font-weight: 900; font-size: .82rem;
-      text-transform: uppercase; letter-spacing: .08em; color: var(--p2);
-      display: flex; align-items: center; justify-content: space-between; gap: 8px;
-    }
-    .room-card-body { padding: 24px; }
-
-    /* ── Grid ── */
-    .grid-outer { overflow-x: auto; padding-bottom: 4px; }
-    #avGrid {
-      border-collapse: separate;
-      border-spacing: 4px;
-      min-width: 480px;
-    }
-
-    /* Column headers */
-    #avGrid thead th {
-      padding: 10px 6px; text-align: center;
-      font-size: .78rem; font-weight: 900;
-      color: var(--p1); background: var(--p4);
-      border-radius: 10px; white-space: nowrap;
-      border: none;
-    }
-    #avGrid thead th:first-child {
-      background: transparent; min-width: 72px;
-    }
-
-    /* Time label cells */
-    #avGrid td.time-lbl {
-      font-size: .72rem; font-weight: 800; color: var(--muted);
-      text-align: right; padding-right: 8px; white-space: nowrap;
-      background: transparent; border: none;
-    }
-
-    /* Tile cells */
-    #avGrid td.tile {
-      width: 54px; height: 40px;
-      border-radius: 10px; border: 2px solid transparent;
-      cursor: pointer;
-      transition: transform .12s, box-shadow .12s, filter .12s;
-      position: relative;
-    }
-    #avGrid td.tile:hover {
-      transform: scale(1.08);
-      box-shadow: 0 4px 12px rgba(0,0,0,.15);
-      filter: brightness(1.05);
-    }
-
-    .t-empty  { background: var(--tile-empty);  border-color: #e5e7eb; }
-    .t-free   { background: var(--tile-free);   border-color: #86efac; }
-    .t-maybe  { background: var(--tile-maybe);  border-color: #fde047; }
-    .t-busy   { background: var(--tile-busy);   border-color: #fca5a5; }
-    .t-best   {
-      background: var(--tile-best) !important;
-      border-color: #a78bfa !important;
-      box-shadow: 0 0 0 2px rgba(109,40,217,.25), 0 0 10px rgba(109,40,217,.35) !important;
-    }
-    .t-best::after {
-      content: '★';
-      position: absolute; top: 2px; right: 4px;
-      font-size: 9px; color: #c4b5fd;
-    }
-
-    /* Legend */
-    .legend-chip {
-      display: inline-flex; align-items: center; gap: 6px;
-      font-size: .78rem; font-weight: 700;
-    }
-    .legend-swatch {
-      width: 20px; height: 20px; border-radius: 6px;
-      flex-shrink: 0;
-    }
-
-    /* Name input area */
-    .name-box {
-      background: var(--p4); border-radius: 16px;
-      padding: 16px 20px; display: flex; align-items: center; gap: 14px;
-    }
-    .name-avatar-placeholder {
-      width: 52px; height: 52px; border-radius: 50%;
-      background: linear-gradient(135deg, var(--p2), var(--pink));
-      display: flex; align-items: center; justify-content: center;
-      font-size: 1.4rem; flex-shrink: 0;
-    }
-
-    /* Submit button */
-    .btn-join {
-      background: linear-gradient(135deg, var(--p2), var(--pink));
-      color: #fff; border: none; border-radius: 50px;
-      font-weight: 900; font-size: 1rem; padding: 14px 40px;
-      box-shadow: 0 4px 20px rgba(124,58,237,.35);
-      transition: transform .15s, box-shadow .15s;
-      text-decoration: none; display: inline-block;
-    }
-    .btn-join:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 8px 28px rgba(124,58,237,.45);
-      color: #fff;
-    }
-
-    footer { background: #0f0e1a; color: rgba(255,255,255,.4); }
-  </style>
-</head>
-<body>
-
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg sm-navbar">
-    <div class="container">
-      <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
-      <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="mainNav">
-        <ul class="navbar-nav me-auto gap-1">
-          <li class="nav-item"><a class="nav-link" href="index.html"><i class="bi bi-house-fill me-1"></i>Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="dashboard.html"><i class="bi bi-grid-fill me-1"></i>My Space</a></li>
-          <li class="nav-item"><a class="nav-link active" href="create-event.html"><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a></li>
-        </ul>
-        <div class="d-flex gap-2 mt-2 mt-lg-0">
-          <a href="#" class="btn-nav-outline">Login</a>
-          <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SmartMeet – Join Room</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg sm-navbar">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
+        <button
+          class="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNav"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav me-auto gap-1">
+            <li class="nav-item">
+              <a class="nav-link" href="index.html"
+                ><i class="bi bi-house-fill me-1"></i>Home</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="dashboard.html"
+                ><i class="bi bi-grid-fill me-1"></i>My Space</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="schedule.html"
+                ><i class="bi bi-calendar-week-fill me-1"></i>My Schedule</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="create-event.html"
+                ><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a
+              >
+            </li>
+          </ul>
+          <div class="d-flex gap-2 mt-2 mt-lg-0">
+            <a href="#" class="btn-nav-outline">Login</a>
+            <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+          </div>
         </div>
       </div>
-    </div>
-  </nav>
+    </nav>
 
-  <!-- Room Banner -->
-  <div class="room-banner">
-    <div class="container position-relative text-center">
-      <div class="room-badge">🚪 Room · Team Sprint Planning</div>
-      <h2 class="pixel-sm mb-2">Mark Your Availability</h2>
-      <p style="opacity:.8;font-size:.95rem;margin-bottom:24px;">Tap the tiles to show when you're free. Let's find the perfect time! 🎯</p>
-
-      <!-- Participant avatars -->
-      <div class="d-flex justify-content-center gap-3 flex-wrap">
-        <div class="part-avatar">
-          <div style="position:relative;display:inline-block;">
-            <div class="part-circle" style="background:linear-gradient(135deg,#f472b6,#a78bfa);">🐱</div>
-            <span class="online-dot" style="position:absolute;bottom:2px;right:2px;"></span>
-          </div>
-          <span class="part-name">MiaW</span>
-        </div>
-        <div class="part-avatar">
-          <div style="position:relative;display:inline-block;">
-            <div class="part-circle" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);">🦊</div>
-            <span class="online-dot" style="position:absolute;bottom:2px;right:2px;"></span>
-          </div>
-          <span class="part-name">FoxDev</span>
-        </div>
-        <div class="part-avatar">
-          <div style="position:relative;display:inline-block;">
-            <div class="part-circle" style="background:linear-gradient(135deg,#4ade80,#0ea5e9);">🐻</div>
-            <span class="online-dot" style="position:absolute;bottom:2px;right:2px;background:#fbbf24;box-shadow:0 0 5px #fbbf24;"></span>
-          </div>
-          <span class="part-name">BearCo</span>
-        </div>
-        <div class="part-avatar">
-          <div style="position:relative;display:inline-block;">
-            <div class="part-circle" style="background:linear-gradient(135deg,#fbbf24,#f472b6);">🐼</div>
-            <span class="online-dot" style="position:absolute;bottom:2px;right:2px;"></span>
-          </div>
-          <span class="part-name">PandaX</span>
-        </div>
-        <!-- "You" slot -->
-        <div class="part-avatar" style="opacity:.5;">
-          <div class="part-circle" style="background:rgba(255,255,255,.1);border-style:dashed;">
-            <i class="bi bi-plus" style="color:#fff;font-size:1.1rem;"></i>
-          </div>
-          <span class="part-name">You?</span>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="container py-4" style="max-width:900px;">
-
-    <!-- Name input -->
-    <div class="name-box mb-4">
-      <div class="name-avatar-placeholder">🧑</div>
-      <div class="flex-grow-1">
-        <label class="form-label mb-1" style="font-weight:900;font-size:.78rem;color:var(--p2);text-transform:uppercase;letter-spacing:.06em;">Your Name</label>
-        <input type="text" class="form-control" placeholder="Enter your name to get started…" value="Alex Johnson" style="border:2px solid #ddd6fe;border-radius:12px;font-weight:700;" />
-      </div>
-    </div>
-
-    <!-- Grid Card -->
-    <div class="room-card mb-4">
-      <div class="room-card-header">
-        <span>🎮 Availability Grid</span>
-        <!-- Legend -->
-        <div class="d-flex gap-3 flex-wrap">
-          <span class="legend-chip">
-            <span class="legend-swatch t-free" style="border:2px solid #86efac;"></span> Free
-          </span>
-          <span class="legend-chip">
-            <span class="legend-swatch t-maybe" style="border:2px solid #fde047;"></span> Maybe
-          </span>
-          <span class="legend-chip">
-            <span class="legend-swatch t-busy" style="border:2px solid #fca5a5;"></span> Busy
-          </span>
-          <span class="legend-chip">
-            <span class="legend-swatch t-best"></span> Best
-          </span>
-          <span class="legend-chip">
-            <span class="legend-swatch t-empty" style="border:2px solid #e5e7eb;"></span> Not set
-          </span>
-        </div>
-      </div>
-      <div class="room-card-body">
-        <p class="text-muted small mb-3">
-          <i class="bi bi-hand-index me-1"></i>
-          Tap a tile to cycle through: <strong>Free → Maybe → Busy → Clear</strong>
+    <!-- Room Banner -->
+    <div class="room-banner">
+      <div class="container position-relative text-center">
+        <div class="room-badge">🚪 Room · Team Sprint Planning</div>
+        <h2 class="pixel-sm mb-2">Mark Your Availability</h2>
+        <p style="opacity: 0.8; font-size: 0.95rem; margin-bottom: 24px">
+          Tap the tiles to show when you're free. Let's find the perfect time!
+          🎯
         </p>
-        <div class="grid-outer">
-          <table id="avGrid">
-            <thead>
-              <tr>
-                <th></th>
-                <th>
-                  <div>Mon</div>
-                  <div style="opacity:.65;font-weight:600;">6 May</div>
-                </th>
-                <th>
-                  <div>Tue</div>
-                  <div style="opacity:.65;font-weight:600;">7 May</div>
-                </th>
-                <th>
-                  <div>Wed</div>
-                  <div style="opacity:.65;font-weight:600;">8 May</div>
-                </th>
-                <th>
-                  <div>Thu</div>
-                  <div style="opacity:.65;font-weight:600;">9 May</div>
-                </th>
-                <th>
-                  <div>Fri</div>
-                  <div style="opacity:.65;font-weight:600;">10 May</div>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td class="time-lbl">9:00 AM</td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-maybe"></td> <td class="tile t-free"></td>  <td class="tile t-empty"></td></tr>
-              <tr><td class="time-lbl">9:30 AM</td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-maybe"></td> <td class="tile t-empty"></td></tr>
-              <tr><td class="time-lbl">10:00 AM</td> <td class="tile t-free"></td>  <td class="tile t-busy"></td>  <td class="tile t-best"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">10:30 AM</td> <td class="tile t-maybe"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">11:00 AM</td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-busy"></td>  <td class="tile t-maybe"></td></tr>
-              <tr><td class="time-lbl">11:30 AM</td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-busy"></td>  <td class="tile t-maybe"></td></tr>
-              <tr><td class="time-lbl">12:00 PM</td> <td class="tile t-empty"></td> <td class="tile t-maybe"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">12:30 PM</td> <td class="tile t-empty"></td> <td class="tile t-maybe"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">1:00 PM</td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-maybe"></td> <td class="tile t-empty"></td> <td class="tile t-busy"></td></tr>
-              <tr><td class="time-lbl">1:30 PM</td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td> <td class="tile t-busy"></td></tr>
-              <tr><td class="time-lbl">2:00 PM</td>  <td class="tile t-maybe"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td></tr>
-              <tr><td class="time-lbl">2:30 PM</td>  <td class="tile t-empty"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td></tr>
-              <tr><td class="time-lbl">3:00 PM</td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td> <td class="tile t-maybe"></td> <td class="tile t-maybe"></td> <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">3:30 PM</td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td> <td class="tile t-maybe"></td> <td class="tile t-busy"></td>  <td class="tile t-free"></td></tr>
-              <tr><td class="time-lbl">4:00 PM</td>  <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-busy"></td>  <td class="tile t-maybe"></td></tr>
-              <tr><td class="time-lbl">4:30 PM</td>  <td class="tile t-busy"></td>  <td class="tile t-free"></td>  <td class="tile t-free"></td>  <td class="tile t-empty"></td> <td class="tile t-maybe"></td></tr>
-            </tbody>
-          </table>
+        <div class="d-flex justify-content-center gap-3 flex-wrap">
+          <div class="part-avatar">
+            <div style="position: relative; display: inline-block">
+              <div
+                class="part-circle"
+                style="background: linear-gradient(135deg, #f472b6, #a78bfa)"
+              >
+                🐱
+              </div>
+              <span
+                class="online-dot"
+                style="position: absolute; bottom: 2px; right: 2px"
+              ></span>
+            </div>
+            <span class="part-name">MiaW</span>
+          </div>
+          <div class="part-avatar">
+            <div style="position: relative; display: inline-block">
+              <div
+                class="part-circle"
+                style="background: linear-gradient(135deg, #22d3ee, #6d28d9)"
+              >
+                🦊
+              </div>
+              <span
+                class="online-dot"
+                style="position: absolute; bottom: 2px; right: 2px"
+              ></span>
+            </div>
+            <span class="part-name">FoxDev</span>
+          </div>
+          <div class="part-avatar">
+            <div style="position: relative; display: inline-block">
+              <div
+                class="part-circle"
+                style="background: linear-gradient(135deg, #4ade80, #0ea5e9)"
+              >
+                🐻
+              </div>
+              <span
+                class="online-dot"
+                style="
+                  position: absolute;
+                  bottom: 2px;
+                  right: 2px;
+                  background: #fbbf24;
+                  box-shadow: 0 0 5px #fbbf24;
+                "
+              ></span>
+            </div>
+            <span class="part-name">BearCo</span>
+          </div>
+          <div class="part-avatar">
+            <div style="position: relative; display: inline-block">
+              <div
+                class="part-circle"
+                style="background: linear-gradient(135deg, #fbbf24, #f472b6)"
+              >
+                🐼
+              </div>
+              <span
+                class="online-dot"
+                style="position: absolute; bottom: 2px; right: 2px"
+              ></span>
+            </div>
+            <span class="part-name">PandaX</span>
+          </div>
+          <div class="part-avatar" style="opacity: 0.5">
+            <div
+              class="part-circle"
+              style="background: rgba(255, 255, 255, 0.1); border-style: dashed"
+            >
+              <i class="bi bi-plus" style="color: #fff; font-size: 1.1rem"></i>
+            </div>
+            <span class="part-name">You?</span>
+          </div>
+        </div>
+        <div class="event-meta">
+          <div class="d-flex justify-content-center gap-2 flex-wrap">
+            <span class="meta-pill"
+              ><i class="bi bi-calendar3 me-1"></i>6 – 10 May 2024</span
+            >
+            <span class="meta-pill"
+              ><i class="bi bi-clock me-1"></i>9:00 AM – 5:00 PM</span
+            >
+            <span class="meta-pill"
+              ><i class="bi bi-people me-1"></i>5 participants</span
+            >
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Submit -->
-    <div class="d-flex flex-column flex-sm-row gap-3 align-items-center justify-content-between">
-      <p class="text-muted small mb-0">
-        <i class="bi bi-info-circle me-1 text-primary"></i>
-        4 of 5 participants have responded so far.
-      </p>
-      <div class="d-flex gap-2">
-        <button class="btn btn-outline-secondary rounded-pill fw-700 px-4">Clear All</button>
-        <a href="results.html" class="btn-join">
-          🎯 Submit Availability
-        </a>
+    <div class="container py-4" style="max-width: 900px">
+      <div class="name-box mb-4">
+        <div class="name-avatar-placeholder">🧑</div>
+        <div class="flex-grow-1">
+          <label
+            class="form-label mb-1"
+            style="
+              font-weight: 900;
+              font-size: 0.78rem;
+              color: var(--p2);
+              text-transform: uppercase;
+              letter-spacing: 0.06em;
+            "
+            >Your Name</label
+          >
+          <input
+            type="text"
+            class="form-control"
+            placeholder="Enter your name to get started…"
+            value="Alex Johnson"
+            style="
+              border: 2px solid #ddd6fe;
+              border-radius: 12px;
+              font-weight: 700;
+            "
+          />
+        </div>
+      </div>
+
+      <div class="instruction-bar mb-4">
+        <i
+          class="bi bi-hand-index-thumb"
+          style="font-size: 1.2rem; flex-shrink: 0"
+        ></i>
+        <span
+          >Click a tile to cycle:
+          <strong>Empty → Free → Maybe → Busy → Empty</strong></span
+        >
+      </div>
+
+      <div class="sm-card mb-4">
+        <div
+          class="sm-card-header"
+          style="justify-content: space-between; flex-wrap: wrap; gap: 10px"
+        >
+          <span>🎮 Availability Grid</span>
+          <div class="d-flex gap-3 flex-wrap align-items-center">
+            <span class="legend-chip"
+              ><span
+                class="legend-swatch t-free"
+                style="border: 2px solid #86efac"
+              ></span
+              >Free</span
+            >
+            <span class="legend-chip"
+              ><span
+                class="legend-swatch t-maybe"
+                style="border: 2px solid #fde047"
+              ></span
+              >Maybe</span
+            >
+            <span class="legend-chip"
+              ><span
+                class="legend-swatch t-busy"
+                style="border: 2px solid #fca5a5"
+              ></span
+              >Busy</span
+            >
+            <span class="legend-chip"
+              ><span
+                class="legend-swatch t-empty"
+                style="border: 2px solid #e5e7eb"
+              ></span
+              >Not set</span
+            >
+          </div>
+        </div>
+        <div class="sm-card-body">
+          <div class="grid-outer">
+            <table class="av-table" id="avGrid">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>
+                    <div>Mon</div>
+                    <div style="opacity: 0.65; font-weight: 600">6 May</div>
+                  </th>
+                  <th>
+                    <div>Tue</div>
+                    <div style="opacity: 0.65; font-weight: 600">7 May</div>
+                  </th>
+                  <th>
+                    <div>Wed</div>
+                    <div style="opacity: 0.65; font-weight: 600">8 May</div>
+                  </th>
+                  <th>
+                    <div>Thu</div>
+                    <div style="opacity: 0.65; font-weight: 600">9 May</div>
+                  </th>
+                  <th>
+                    <div>Fri</div>
+                    <div style="opacity: 0.65; font-weight: 600">10 May</div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="hour-start">
+                  <td class="time-lbl">9:00 AM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">9:30 AM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-empty"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">10:00 AM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">10:30 AM</td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">11:00 AM</td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-maybe"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">11:30 AM</td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-maybe"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">12:00 PM</td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">12:30 PM</td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">1:00 PM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-busy"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">1:30 PM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-busy"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">2:00 PM</td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">2:30 PM</td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">3:00 PM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">3:30 PM</td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-maybe"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">4:00 PM</td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-maybe"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">4:30 PM</td>
+                  <td class="tile t-busy"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-free"></td>
+                  <td class="tile t-empty"></td>
+                  <td class="tile t-maybe"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="response-bar mb-4">
+        <div class="d-flex justify-content-between align-items-center">
+          <span style="font-weight: 800; font-size: 0.88rem"
+            ><i class="bi bi-people me-2" style="color: var(--p2)"></i>Responses
+            so far</span
+          >
+          <span style="font-weight: 900; color: var(--p2)"
+            >4 / 5 participants</span
+          >
+        </div>
+        <div class="response-track">
+          <div class="response-fill" style="width: 80%"></div>
+        </div>
+      </div>
+
+      <div
+        class="d-flex flex-column flex-sm-row gap-3 align-items-center justify-content-between"
+      >
+        <p class="text-muted small mb-0">
+          <i class="bi bi-info-circle me-1 text-primary"></i>
+          You can update your availability any time before the deadline.
+        </p>
+        <div class="d-flex gap-2">
+          <button class="btn btn-outline-secondary rounded-pill fw-700 px-4">
+            Clear All
+          </button>
+          <a href="results.html" class="btn-join">🎯 Submit Availability</a>
+        </div>
       </div>
     </div>
 
-  </div>
+    <footer class="py-4 text-center">
+      <div class="container">
+        <p class="mb-0 small">
+          © 2026 SmartMeet · CITS3403 Project · University of Western Australia
+        </p>
+      </div>
+    </footer>
 
-  <!-- Footer -->
-  <footer class="py-4 text-center">
-    <div class="container">
-      <p class="mb-0 small">© 2024 SmartMeet · CITS3403 Project · University of Western Australia</p>
-    </div>
-  </footer>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
-  <!-- Minimal tile-cycle interaction (vanilla JS, no frameworks) -->
-  <script>
-    const states = ['t-empty', 't-free', 't-maybe', 't-busy'];
-    document.querySelectorAll('#avGrid td.tile').forEach(td => {
-      // skip best tiles so the demo star stays visible
-      if (td.classList.contains('t-best')) return;
-      td.addEventListener('click', () => {
-        const cur = states.find(s => td.classList.contains(s)) || 't-empty';
-        const next = states[(states.indexOf(cur) + 1) % states.length];
-        td.classList.remove(...states);
-        td.classList.add(next);
-      });
-    });
-  </script>
-</body>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,433 +1,791 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SmartMeet – My Mini Space</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --p1: #6d28d9; --p2: #7c3aed; --p3: #a78bfa; --p4: #ede9fe;
-      --pink: #f472b6; --cyan: #22d3ee; --green: #4ade80; --yellow: #fbbf24;
-      --bg: #f5f3ff; --card: #ffffff; --text: #1e1b4b; --muted: #6b7280;
-    }
-    * { box-sizing: border-box; }
-    body { font-family: 'Nunito', sans-serif; background: var(--bg); color: var(--text); margin: 0; min-height: 100vh; }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SmartMeet – My Space</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg sm-navbar">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
+        <button
+          class="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNav"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav me-auto gap-1">
+            <li class="nav-item">
+              <a class="nav-link" href="index.html"
+                ><i class="bi bi-house-fill me-1"></i>Home</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" href="dashboard.html"
+                ><i class="bi bi-grid-fill me-1"></i>My Space</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="schedule.html"
+                ><i class="bi bi-calendar-week-fill me-1"></i>My Schedule</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="create-event.html"
+                ><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a
+              >
+            </li>
+          </ul>
+          <div class="d-flex gap-2 mt-2 mt-lg-0">
+            <a href="#" class="btn-nav-outline">Login</a>
+            <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+          </div>
+        </div>
+      </div>
+    </nav>
 
-    /* Navbar */
-    .sm-navbar {
-      background: linear-gradient(90deg, #1e1b4b 0%, #4c1d95 60%, #6d28d9 100%);
-      padding: .6rem 0; box-shadow: 0 2px 16px rgba(109,40,217,.4);
-    }
-    .sm-navbar .navbar-brand {
-      font-family: 'Press Start 2P', monospace; font-size: .9rem;
-      color: #fff; letter-spacing: 1px;
-    }
-    .sm-navbar .navbar-brand span { color: var(--cyan); }
-    .sm-navbar .nav-link {
-      color: rgba(255,255,255,.8) !important; font-weight: 700; font-size: .85rem;
-      padding: 6px 14px !important; border-radius: 20px; transition: background .2s;
-    }
-    .sm-navbar .nav-link:hover, .sm-navbar .nav-link.active {
-      background: rgba(255,255,255,.15); color: #fff !important;
-    }
-    .btn-nav-pink {
-      background: var(--pink); color: #fff; border: none; border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 6px 16px; transition: transform .15s;
-    }
-    .btn-nav-pink:hover { transform: translateY(-2px); color: #fff; }
-    .btn-nav-outline {
-      background: transparent; color: #fff;
-      border: 2px solid rgba(255,255,255,.4); border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 5px 16px; transition: background .2s;
-    }
-    .btn-nav-outline:hover { background: rgba(255,255,255,.15); color: #fff; }
+    <div class="space-bg">
+      <div class="container">
+        <div class="row g-4">
+          <!-- Sidebar -->
+          <div class="col-lg-3">
+            <div class="profile-card">
+              <div class="profile-card-banner">
+                <span class="deco" style="top: 10px; left: 20px">⭐</span>
+                <span class="deco" style="top: 20px; right: 40px">🌙</span>
+                <span class="deco" style="bottom: 8px; left: 60px">✨</span>
+              </div>
+              <div
+                style="
+                  position: relative;
+                  display: inline-block;
+                  left: 50%;
+                  transform: translateX(-50%);
+                "
+              >
+                <div class="profile-avatar">🐱</div>
+                <span class="online-badge"></span>
+              </div>
+              <div class="profile-card-body mt-2">
+                <div class="fw-900 fs-5">Jane Smith</div>
+                <div class="text-muted small fw-600 mb-1">@janesmeet</div>
+                <div
+                  class="d-inline-block px-3 py-1 rounded-pill mb-3"
+                  style="
+                    background: linear-gradient(90deg, #ede9fe, #fce7f3);
+                    font-size: 0.78rem;
+                    font-weight: 700;
+                    color: var(--p2);
+                  "
+                >
+                  ✨ Organizing wizard
+                </div>
+                <div class="text-muted small fst-italic mb-3">
+                  "Life's too short for bad meeting times 🕐"
+                </div>
+                <div
+                  class="d-flex justify-content-between mb-1"
+                  style="
+                    font-size: 0.72rem;
+                    font-weight: 800;
+                    color: var(--muted);
+                  "
+                >
+                  <span>LEVEL 7 · PLANNER</span><span>640 / 1000 XP</span>
+                </div>
+                <div class="xp-bar mb-3">
+                  <div class="xp-fill" style="width: 64%"></div>
+                </div>
+                <div class="d-flex gap-2 mb-4">
+                  <div class="stat-pill">
+                    <div class="val">5</div>
+                    <div class="lbl">Rooms</div>
+                  </div>
+                  <div class="stat-pill">
+                    <div class="val">12</div>
+                    <div class="lbl">Friends</div>
+                  </div>
+                  <div class="stat-pill">
+                    <div class="val">28</div>
+                    <div class="lbl">Meets</div>
+                  </div>
+                </div>
+                <a href="dashboard.html" class="side-menu-item active"
+                  ><span class="side-icon">🏠</span> My Rooms</a
+                >
+                <a href="schedule.html" class="side-menu-item"
+                  ><span class="side-icon">🗓️</span> My Schedule</a
+                >
+                <a href="#" class="side-menu-item"
+                  ><span class="side-icon">👥</span> Friends</a
+                >
+                <a href="#" class="side-menu-item">
+                  <span class="side-icon">🔔</span> Notifications
+                  <span
+                    class="badge ms-auto"
+                    style="background: var(--pink); font-size: 0.65rem"
+                    >3</span
+                  >
+                </a>
+                <a href="#" class="side-menu-item"
+                  ><span class="side-icon">⚙️</span> Settings</a
+                >
+              </div>
+            </div>
+          </div>
 
-    /* Space background */
-    .space-bg {
-      background:
-        radial-gradient(ellipse at 15% 40%, rgba(124,58,237,.08) 0%, transparent 50%),
-        radial-gradient(ellipse at 85% 70%, rgba(244,114,182,.07) 0%, transparent 50%),
-        var(--bg);
-      min-height: calc(100vh - 60px);
-      padding: 40px 0 60px;
-    }
+          <!-- Main Content -->
+          <div class="col-lg-9">
+            <div
+              class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3"
+            >
+              <div>
+                <p class="section-sub">My Mini Space</p>
+                <h2 class="fw-900 mb-0" style="font-size: 1.6rem">
+                  Hey Jane, welcome back! 🌟
+                </h2>
+              </div>
+              <a
+                href="create-event.html"
+                class="btn-room py-2 px-4"
+                style="font-size: 0.9rem"
+                >✨ Create New Room</a
+              >
+            </div>
 
-    /* Profile card */
-    .profile-card {
-      background: var(--card);
-      border-radius: 24px;
-      border: 2px solid var(--p4);
-      box-shadow: 0 8px 32px rgba(109,40,217,.1);
-      overflow: hidden;
-      position: sticky; top: 24px;
-    }
-    .profile-card-banner {
-      height: 80px;
-      background: linear-gradient(135deg, #4c1d95, var(--pink));
-      position: relative;
-    }
-    .profile-card-banner .deco {
-      position: absolute; font-size: 1.4rem; opacity: .25;
-    }
-    .profile-avatar {
-      width: 76px; height: 76px; border-radius: 50%;
-      background: linear-gradient(135deg, var(--p2), var(--pink));
-      display: flex; align-items: center; justify-content: center;
-      font-size: 2rem;
-      border: 4px solid var(--card);
-      margin: -38px auto 0;
-      position: relative; z-index: 1;
-    }
-    .online-badge {
-      position: absolute; bottom: 4px; right: 4px;
-      width: 14px; height: 14px; border-radius: 50%;
-      background: var(--green);
-      border: 3px solid var(--card);
-      box-shadow: 0 0 6px var(--green);
-    }
-    .profile-card-body { padding: 0 20px 20px; text-align: center; }
-    .xp-bar {
-      height: 8px; border-radius: 20px;
-      background: var(--p4); overflow: hidden; margin-top: 4px;
-    }
-    .xp-fill {
-      height: 100%; border-radius: 20px;
-      background: linear-gradient(90deg, var(--p2), var(--cyan));
-    }
-    .stat-pill {
-      background: var(--p4); border-radius: 12px;
-      padding: 8px 12px; text-align: center; flex: 1;
-    }
-    .stat-pill .val { font-weight: 900; font-size: 1.1rem; color: var(--p2); }
-    .stat-pill .lbl { font-size: .68rem; font-weight: 700; color: var(--muted); text-transform: uppercase; }
+            <div class="notif-bar mb-4">
+              <span style="font-size: 1.4rem">🔔</span>
+              <div class="flex-grow-1">
+                <span class="fw-800">PandaX</span> just submitted their
+                availability for
+                <span class="fw-800">Team Sprint Planning</span>.
+                <a
+                  href="results.html"
+                  class="ms-2 fw-700"
+                  style="color: var(--p2); text-decoration: none"
+                  >View Results →</a
+                >
+              </div>
+            </div>
 
-    /* Nav menu inside profile */
-    .side-menu-item {
-      display: flex; align-items: center; gap: 10px;
-      padding: 10px 14px; border-radius: 12px;
-      font-weight: 700; font-size: .9rem; color: var(--text);
-      text-decoration: none; transition: background .2s;
-      cursor: pointer;
-    }
-    .side-menu-item:hover { background: var(--p4); color: var(--p2); }
-    .side-menu-item.active { background: var(--p4); color: var(--p2); }
-    .side-icon { font-size: 1.1rem; width: 28px; text-align: center; }
+            <p class="section-sub">Active Rooms</p>
+            <div class="section-header">
+              Rooms You Created
+              <span
+                class="badge rounded-pill ms-2"
+                style="
+                  background: var(--p4);
+                  color: var(--p2);
+                  font-size: 0.75rem;
+                "
+                >4</span
+              >
+            </div>
 
-    /* Room cards */
-    .room-card {
-      background: var(--card); border-radius: 20px;
-      border: 2px solid var(--p4);
-      box-shadow: 0 4px 18px rgba(109,40,217,.07);
-      transition: transform .18s, box-shadow .18s, border-color .18s;
-      overflow: hidden; height: 100%;
-    }
-    .room-card:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 12px 32px rgba(109,40,217,.16);
-      border-color: var(--p3);
-    }
-    .room-card-top {
-      height: 56px;
-      display: flex; align-items: center; justify-content: space-between;
-      padding: 0 18px;
-    }
-    .room-card-body { padding: 14px 18px 18px; }
-    .status-chip {
-      display: inline-block; font-size: .7rem; font-weight: 800;
-      padding: 3px 10px; border-radius: 20px;
-    }
-    .chip-waiting  { background: #fef3c7; color: #92400e; }
-    .chip-done     { background: #d1fae5; color: #065f46; }
-    .chip-new      { background: #e0e7ff; color: #3730a3; }
+            <div class="row g-3">
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #4c1d95, #7c3aed)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >🚀 Team Sprint Planning</span
+                    >
+                    <span class="status-chip chip-waiting">Awaiting</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">6–10 May 2024</p>
+                      <span class="deadline-badge deadline-soon"
+                        ><i class="bi bi-clock me-1"></i>Closes 5 May</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #f472b6,
+                              #a78bfa
+                            );
+                          "
+                          >🐱</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #22d3ee,
+                              #6d28d9
+                            );
+                          "
+                          >🦊</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #4ade80,
+                              #0ea5e9
+                            );
+                          "
+                          >🐻</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >3 / 5 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-3">
+                      <div
+                        class="progress-bar"
+                        style="width: 60%; background: var(--yellow)"
+                      ></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="availability.html"
+                        class="btn btn-outline-primary btn-sm rounded-pill fw-700 flex-grow-1"
+                        >View Grid</a
+                      >
+                      <a
+                        href="results.html"
+                        class="btn-room flex-grow-1 text-center py-1"
+                        >Results</a
+                      >
+                      <button
+                        class="btn btn-outline-secondary btn-sm rounded-pill fw-700 px-3"
+                        title="Copy share link"
+                      >
+                        <i class="bi bi-share"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    /* Tiny avatars for cards */
-    .mini-avatar {
-      width: 26px; height: 26px; border-radius: 50%;
-      display: inline-flex; align-items: center; justify-content: center;
-      font-size: .9rem; border: 2px solid #fff; margin-left: -6px;
-    }
-    .mini-avatar:first-child { margin-left: 0; }
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #065f46, #059669)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >🎯 Project Kickoff</span
+                    >
+                    <span class="status-chip chip-done">Confirmed!</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">1–3 May 2024</p>
+                      <span class="deadline-badge deadline-closed"
+                        ><i class="bi bi-lock me-1"></i>Closed</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #f472b6,
+                              #a78bfa
+                            );
+                          "
+                          >🐱</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #22d3ee,
+                              #6d28d9
+                            );
+                          "
+                          >🦊</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #4ade80,
+                              #0ea5e9
+                            );
+                          "
+                          >🐻</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #fbbf24,
+                              #f472b6
+                            );
+                          "
+                          >🐼</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >4 / 4 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-3">
+                      <div
+                        class="progress-bar bg-success"
+                        style="width: 100%"
+                      ></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="availability.html"
+                        class="btn btn-outline-success btn-sm rounded-pill fw-700 flex-grow-1"
+                        >View Grid</a
+                      >
+                      <a
+                        href="results.html"
+                        class="btn-room flex-grow-1 text-center py-1"
+                        >Results</a
+                      >
+                      <button
+                        class="btn btn-outline-secondary btn-sm rounded-pill fw-700 px-3"
+                        title="Copy share link"
+                      >
+                        <i class="bi bi-share"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    .progress { height: 6px; border-radius: 20px; }
-    .progress-bar { border-radius: 20px; }
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #1e3a5f, #0ea5e9)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >🎨 Design Review</span
+                    >
+                    <span class="status-chip chip-done">Confirmed!</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">15–17 Apr 2024</p>
+                      <span class="deadline-badge deadline-closed"
+                        ><i class="bi bi-lock me-1"></i>Closed</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #f472b6,
+                              #a78bfa
+                            );
+                          "
+                          >🐱</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #22d3ee,
+                              #6d28d9
+                            );
+                          "
+                          >🦊</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #a78bfa,
+                              #22d3ee
+                            );
+                          "
+                          >🦋</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #4ade80,
+                              #0ea5e9
+                            );
+                          "
+                          >🐻</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #fbbf24,
+                              #f472b6
+                            );
+                          "
+                          >🐼</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >5 / 5 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-3">
+                      <div
+                        class="progress-bar bg-info"
+                        style="width: 100%"
+                      ></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="availability.html"
+                        class="btn btn-outline-info btn-sm rounded-pill fw-700 flex-grow-1"
+                        >View Grid</a
+                      >
+                      <a
+                        href="results.html"
+                        class="btn-room flex-grow-1 text-center py-1"
+                        >Results</a
+                      >
+                      <button
+                        class="btn btn-outline-secondary btn-sm rounded-pill fw-700 px-3"
+                        title="Copy share link"
+                      >
+                        <i class="bi bi-share"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    .btn-room {
-      background: linear-gradient(135deg, var(--p2), var(--pink));
-      color: #fff; border: none; border-radius: 50px;
-      font-weight: 800; font-size: .82rem; padding: 7px 18px;
-      transition: transform .15s, box-shadow .15s;
-      text-decoration: none;
-    }
-    .btn-room:hover { transform: translateY(-2px); box-shadow: 0 4px 14px rgba(124,58,237,.35); color: #fff; }
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #4a1942, #a855f7)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >🔄 Q2 Retrospective</span
+                    >
+                    <span class="status-chip chip-waiting">Awaiting</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">20–24 May 2024</p>
+                      <span class="deadline-badge deadline-ok"
+                        ><i class="bi bi-clock me-1"></i>Closes 19 May</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #f472b6,
+                              #a78bfa
+                            );
+                          "
+                          >🐱</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >1 / 6 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-3">
+                      <div
+                        class="progress-bar"
+                        style="width: 17%; background: var(--yellow)"
+                      ></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="availability.html"
+                        class="btn btn-outline-primary btn-sm rounded-pill fw-700 flex-grow-1"
+                        >View Grid</a
+                      >
+                      <a
+                        href="results.html"
+                        class="btn-room flex-grow-1 text-center py-1"
+                        >Results</a
+                      >
+                      <button
+                        class="btn btn-outline-secondary btn-sm rounded-pill fw-700 px-3"
+                        title="Copy share link"
+                      >
+                        <i class="bi bi-share"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-    .section-header { font-weight: 900; font-size: 1.1rem; color: var(--text); margin-bottom: 16px; }
-    .section-sub { font-size: .78rem; font-weight: 800; color: var(--p2); text-transform: uppercase; letter-spacing: .08em; margin-bottom: 4px; }
+              <div class="col-md-6">
+                <a href="create-event.html" class="text-decoration-none">
+                  <div
+                    class="room-card d-flex flex-column align-items-center justify-content-center py-5"
+                    style="
+                      border-style: dashed;
+                      border-color: #c4b5fd;
+                      background: transparent;
+                      min-height: 200px;
+                      cursor: pointer;
+                    "
+                  >
+                    <div style="font-size: 2.5rem; margin-bottom: 12px">➕</div>
+                    <div class="fw-800" style="color: var(--p2)">
+                      Create New Room
+                    </div>
+                    <div class="text-muted small mt-1">
+                      Start planning your next meeting
+                    </div>
+                  </div>
+                </a>
+              </div>
+            </div>
 
-    footer { background: #0f0e1a; color: rgba(255,255,255,.4); }
-  </style>
-</head>
-<body>
+            <hr class="section-divider" />
 
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg sm-navbar">
-    <div class="container">
-      <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
-      <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="mainNav">
-        <ul class="navbar-nav me-auto gap-1">
-          <li class="nav-item"><a class="nav-link" href="index.html"><i class="bi bi-house-fill me-1"></i>Home</a></li>
-          <li class="nav-item"><a class="nav-link active" href="dashboard.html"><i class="bi bi-grid-fill me-1"></i>My Space</a></li>
-          <li class="nav-item"><a class="nav-link" href="create-event.html"><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a></li>
-        </ul>
-        <div class="d-flex gap-2 mt-2 mt-lg-0">
-          <a href="#" class="btn-nav-outline">Login</a>
-          <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+            <p class="section-sub">Invited Rooms</p>
+            <div class="section-header">
+              Rooms You're Invited To
+              <span
+                class="badge rounded-pill ms-2"
+                style="
+                  background: var(--p4);
+                  color: var(--p2);
+                  font-size: 0.75rem;
+                "
+                >2</span
+              >
+            </div>
+
+            <div class="row g-3">
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #134e4a, #0d9488)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >📚 Study Group Finals</span
+                    >
+                    <span class="status-chip chip-invited">Invited</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">12–16 May 2024</p>
+                      <span class="deadline-badge deadline-soon"
+                        ><i class="bi bi-clock me-1"></i>Closes 11 May</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #22d3ee,
+                              #6d28d9
+                            );
+                          "
+                          >🦊</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #4ade80,
+                              #0ea5e9
+                            );
+                          "
+                          >🐻</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >2 / 4 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-1">
+                      <div
+                        class="progress-bar"
+                        style="width: 50%; background: var(--yellow)"
+                      ></div>
+                    </div>
+                    <p class="text-muted small mb-3 mt-2">
+                      <i class="bi bi-person me-1"></i>Organised by
+                      <strong>FoxDev</strong>
+                    </p>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="availability.html"
+                        class="btn-room flex-grow-1 text-center py-2"
+                        >✏️ Mark My Availability</a
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="col-md-6">
+                <div class="room-card">
+                  <div
+                    class="room-card-top"
+                    style="background: linear-gradient(90deg, #7f1d1d, #dc2626)"
+                  >
+                    <span
+                      style="color: #fff; font-weight: 800; font-size: 0.9rem"
+                      >🍕 Team Lunch</span
+                    >
+                    <span class="status-chip chip-done">Confirmed!</span>
+                  </div>
+                  <div class="room-card-body">
+                    <div
+                      class="d-flex justify-content-between align-items-center mb-1"
+                    >
+                      <p class="text-muted small mb-0">3 May 2024</p>
+                      <span class="deadline-badge deadline-closed"
+                        ><i class="bi bi-lock me-1"></i>Closed</span
+                      >
+                    </div>
+                    <div class="d-flex align-items-center gap-2 mb-2 mt-2">
+                      <div>
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #f472b6,
+                              #a78bfa
+                            );
+                          "
+                          >🐱</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #22d3ee,
+                              #6d28d9
+                            );
+                          "
+                          >🦊</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #4ade80,
+                              #0ea5e9
+                            );
+                          "
+                          >🐻</span
+                        >
+                        <span
+                          class="mini-avatar"
+                          style="
+                            background: linear-gradient(
+                              135deg,
+                              #fbbf24,
+                              #f472b6
+                            );
+                          "
+                          >🐼</span
+                        >
+                      </div>
+                      <span class="text-muted small fw-700"
+                        >4 / 4 responded</span
+                      >
+                    </div>
+                    <div class="progress mb-1">
+                      <div
+                        class="progress-bar bg-success"
+                        style="width: 100%"
+                      ></div>
+                    </div>
+                    <p class="text-muted small mb-3 mt-2">
+                      <i class="bi bi-person me-1"></i>Organised by
+                      <strong>BearCo</strong>
+                    </p>
+                    <div class="d-flex gap-2">
+                      <a
+                        href="results.html"
+                        class="btn btn-outline-success btn-sm rounded-pill fw-700 flex-grow-1"
+                        >View Results</a
+                      >
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </nav>
 
-  <div class="space-bg">
-    <div class="container">
-      <div class="row g-4">
-
-        <!-- Sidebar: Profile Card -->
-        <div class="col-lg-3">
-          <div class="profile-card">
-            <div class="profile-card-banner">
-              <span class="deco" style="top:10px;left:20px;">⭐</span>
-              <span class="deco" style="top:20px;right:40px;">🌙</span>
-              <span class="deco" style="bottom:8px;left:60px;">✨</span>
-            </div>
-            <div style="position:relative;display:inline-block;left:50%;transform:translateX(-50%);">
-              <div class="profile-avatar">🐱</div>
-              <span class="online-badge"></span>
-            </div>
-            <div class="profile-card-body mt-2">
-              <div class="fw-900 fs-5">Jane Smith</div>
-              <div class="text-muted small fw-600 mb-1">@janesmeet</div>
-              <div class="d-inline-block px-3 py-1 rounded-pill mb-3" style="background:linear-gradient(90deg,#ede9fe,#fce7f3);font-size:.78rem;font-weight:700;color:var(--p2);">
-                ✨ Organizing wizard
-              </div>
-              <div class="text-muted small fst-italic mb-3">"Life's too short for bad meeting times 🕐"</div>
-
-              <!-- XP -->
-              <div class="d-flex justify-content-between mb-1" style="font-size:.72rem;font-weight:800;color:var(--muted);">
-                <span>LEVEL 7 · PLANNER</span><span>640 / 1000 XP</span>
-              </div>
-              <div class="xp-bar mb-3">
-                <div class="xp-fill" style="width:64%;"></div>
-              </div>
-
-              <!-- Stats -->
-              <div class="d-flex gap-2 mb-4">
-                <div class="stat-pill">
-                  <div class="val">5</div>
-                  <div class="lbl">Rooms</div>
-                </div>
-                <div class="stat-pill">
-                  <div class="val">12</div>
-                  <div class="lbl">Friends</div>
-                </div>
-                <div class="stat-pill">
-                  <div class="val">28</div>
-                  <div class="lbl">Meets</div>
-                </div>
-              </div>
-
-              <!-- Side menu -->
-              <a href="dashboard.html" class="side-menu-item active">
-                <span class="side-icon">🏠</span> My Rooms
-              </a>
-              <a href="#" class="side-menu-item">
-                <span class="side-icon">👥</span> Friends
-              </a>
-              <a href="#" class="side-menu-item">
-                <span class="side-icon">🔔</span> Notifications
-                <span class="badge ms-auto" style="background:var(--pink);font-size:.65rem;">3</span>
-              </a>
-              <a href="#" class="side-menu-item">
-                <span class="side-icon">⚙️</span> Settings
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Main Content -->
-        <div class="col-lg-9">
-
-          <!-- Greeting -->
-          <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
-            <div>
-              <p class="section-sub">My Mini Space</p>
-              <h2 class="fw-900 mb-0" style="font-size:1.6rem;">Hey Jane, welcome back! 🌟</h2>
-            </div>
-            <a href="create-event.html" class="btn-room py-2 px-4" style="font-size:.9rem;">
-              ✨ Create New Room
-            </a>
-          </div>
-
-          <!-- Notification bar -->
-          <div class="d-flex align-items-center gap-3 p-3 rounded-3 mb-4" style="background:linear-gradient(90deg,#ede9fe,#fce7f3);border:2px solid #ddd6fe;">
-            <span style="font-size:1.4rem;">🔔</span>
-            <div class="flex-grow-1">
-              <span class="fw-800">PandaX</span> just submitted their availability for <span class="fw-800">Team Sprint Planning</span>.
-              <a href="results.html" class="ms-2 fw-700" style="color:var(--p2);text-decoration:none;">View Results →</a>
-            </div>
-          </div>
-
-          <!-- Active Rooms -->
-          <p class="section-sub">Active Rooms</p>
-          <div class="section-header">Your Rooms <span class="badge rounded-pill ms-2" style="background:var(--p4);color:var(--p2);font-size:.75rem;">5</span></div>
-
-          <div class="row g-3">
-
-            <!-- Card 1 -->
-            <div class="col-md-6">
-              <div class="room-card">
-                <div class="room-card-top" style="background:linear-gradient(90deg,#4c1d95,#7c3aed);">
-                  <span style="color:#fff;font-weight:800;font-size:.9rem;">🚀 Team Sprint Planning</span>
-                  <span class="status-chip chip-waiting">Awaiting</span>
-                </div>
-                <div class="room-card-body">
-                  <p class="text-muted small mb-2">Weekly planning — 6–10 May 2024</p>
-                  <div class="d-flex align-items-center gap-2 mb-2">
-                    <div>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#f472b6,#a78bfa);">🐱</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);">🦊</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#4ade80,#0ea5e9);">🐻</span>
-                    </div>
-                    <span class="text-muted small fw-700">3 / 5 responded</span>
-                  </div>
-                  <div class="progress mb-3">
-                    <div class="progress-bar" style="width:60%;background:var(--yellow);"></div>
-                  </div>
-                  <div class="d-flex gap-2">
-                    <a href="availability.html" class="btn btn-outline-primary btn-sm rounded-pill fw-700 flex-grow-1">View Grid</a>
-                    <a href="results.html" class="btn-room flex-grow-1 text-center py-1">Results</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Card 2 -->
-            <div class="col-md-6">
-              <div class="room-card">
-                <div class="room-card-top" style="background:linear-gradient(90deg,#065f46,#059669);">
-                  <span style="color:#fff;font-weight:800;font-size:.9rem;">🎯 Project Kickoff</span>
-                  <span class="status-chip chip-done">Confirmed!</span>
-                </div>
-                <div class="room-card-body">
-                  <p class="text-muted small mb-2">Initial alignment — 1–3 May 2024</p>
-                  <div class="d-flex align-items-center gap-2 mb-2">
-                    <div>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#f472b6,#a78bfa);">🐱</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);">🦊</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#4ade80,#0ea5e9);">🐻</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#fbbf24,#f472b6);">🐼</span>
-                    </div>
-                    <span class="text-muted small fw-700">4 / 4 responded</span>
-                  </div>
-                  <div class="progress mb-3">
-                    <div class="progress-bar bg-success" style="width:100%;"></div>
-                  </div>
-                  <div class="d-flex gap-2">
-                    <a href="availability.html" class="btn btn-outline-success btn-sm rounded-pill fw-700 flex-grow-1">View Grid</a>
-                    <a href="results.html" class="btn-room flex-grow-1 text-center py-1">Results</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Card 3 -->
-            <div class="col-md-6">
-              <div class="room-card">
-                <div class="room-card-top" style="background:linear-gradient(90deg,#1e3a5f,#0ea5e9);">
-                  <span style="color:#fff;font-weight:800;font-size:.9rem;">🎨 Design Review</span>
-                  <span class="status-chip chip-done">Confirmed!</span>
-                </div>
-                <div class="room-card-body">
-                  <p class="text-muted small mb-2">Wireframe review — 15–17 Apr 2024</p>
-                  <div class="d-flex align-items-center gap-2 mb-2">
-                    <div>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#f472b6,#a78bfa);">🐱</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);">🦊</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#a78bfa,#22d3ee);">🦋</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#4ade80,#0ea5e9);">🐻</span>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#fbbf24,#f472b6);">🐼</span>
-                    </div>
-                    <span class="text-muted small fw-700">5 / 5 responded</span>
-                  </div>
-                  <div class="progress mb-3">
-                    <div class="progress-bar bg-info" style="width:100%;"></div>
-                  </div>
-                  <div class="d-flex gap-2">
-                    <a href="availability.html" class="btn btn-outline-info btn-sm rounded-pill fw-700 flex-grow-1">View Grid</a>
-                    <a href="results.html" class="btn-room flex-grow-1 text-center py-1">Results</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Card 4 -->
-            <div class="col-md-6">
-              <div class="room-card">
-                <div class="room-card-top" style="background:linear-gradient(90deg,#4a1942,#a855f7);">
-                  <span style="color:#fff;font-weight:800;font-size:.9rem;">🔄 Q2 Retrospective</span>
-                  <span class="status-chip chip-waiting">Awaiting</span>
-                </div>
-                <div class="room-card-body">
-                  <p class="text-muted small mb-2">End-of-quarter retro — 20–24 May 2024</p>
-                  <div class="d-flex align-items-center gap-2 mb-2">
-                    <div>
-                      <span class="mini-avatar" style="background:linear-gradient(135deg,#f472b6,#a78bfa);">🐱</span>
-                    </div>
-                    <span class="text-muted small fw-700">1 / 6 responded</span>
-                  </div>
-                  <div class="progress mb-3">
-                    <div class="progress-bar" style="width:17%;background:var(--yellow);"></div>
-                  </div>
-                  <div class="d-flex gap-2">
-                    <a href="availability.html" class="btn btn-outline-primary btn-sm rounded-pill fw-700 flex-grow-1">View Grid</a>
-                    <button class="btn btn-outline-secondary btn-sm rounded-pill fw-700 flex-grow-1">
-                      <i class="bi bi-share me-1"></i>Share
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- New Room CTA card -->
-            <div class="col-md-6">
-              <a href="create-event.html" class="text-decoration-none">
-                <div class="room-card d-flex flex-column align-items-center justify-content-center py-5"
-                  style="border-style:dashed;border-color:#c4b5fd;background:transparent;min-height:200px;cursor:pointer;">
-                  <div style="font-size:2.5rem;margin-bottom:12px;">➕</div>
-                  <div class="fw-800" style="color:var(--p2);">Create New Room</div>
-                  <div class="text-muted small mt-1">Start planning your next meeting</div>
-                </div>
-              </a>
-            </div>
-
-          </div>
-        </div>
-
+    <footer class="py-4 text-center">
+      <div class="container">
+        <p class="mb-0 small">
+          © 2026 SmartMeet · CITS3403 Project · University of Western Australia
+        </p>
       </div>
-    </div>
-  </div>
+    </footer>
 
-  <!-- Footer -->
-  <footer class="py-4 text-center">
-    <div class="container">
-      <p class="mb-0 small">© 2024 SmartMeet · CITS3403 Project · University of Western Australia</p>
-    </div>
-  </footer>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
 </html>

--- a/results.html
+++ b/results.html
@@ -1,411 +1,796 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SmartMeet – Best Time Found!</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
-  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --p1: #6d28d9; --p2: #7c3aed; --p3: #a78bfa; --p4: #ede9fe;
-      --pink: #f472b6; --cyan: #22d3ee; --green: #4ade80; --yellow: #fbbf24;
-      --bg: #f5f3ff; --card: #ffffff; --text: #1e1b4b; --muted: #6b7280;
-    }
-    * { box-sizing: border-box; }
-    body { font-family: 'Nunito', sans-serif; background: var(--bg); color: var(--text); margin: 0; }
-
-    /* Navbar */
-    .sm-navbar {
-      background: linear-gradient(90deg, #1e1b4b 0%, #4c1d95 60%, #6d28d9 100%);
-      padding: .6rem 0; box-shadow: 0 2px 16px rgba(109,40,217,.4);
-    }
-    .sm-navbar .navbar-brand {
-      font-family: 'Press Start 2P', monospace; font-size: .9rem;
-      color: #fff; letter-spacing: 1px;
-    }
-    .sm-navbar .navbar-brand span { color: var(--cyan); }
-    .sm-navbar .nav-link {
-      color: rgba(255,255,255,.8) !important; font-weight: 700; font-size: .85rem;
-      padding: 6px 14px !important; border-radius: 20px; transition: background .2s;
-    }
-    .sm-navbar .nav-link:hover, .sm-navbar .nav-link.active {
-      background: rgba(255,255,255,.15); color: #fff !important;
-    }
-    .btn-nav-pink {
-      background: var(--pink); color: #fff; border: none; border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 6px 16px; transition: transform .15s;
-    }
-    .btn-nav-pink:hover { transform: translateY(-2px); color: #fff; }
-    .btn-nav-outline {
-      background: transparent; color: #fff;
-      border: 2px solid rgba(255,255,255,.4); border-radius: 20px;
-      font-weight: 700; font-size: .82rem; padding: 5px 16px; transition: background .2s;
-    }
-    .btn-nav-outline:hover { background: rgba(255,255,255,.15); color: #fff; }
-
-    /* Confetti-style header */
-    .result-header {
-      background: linear-gradient(135deg, #1e1b4b 0%, #4c1d95 45%, #7c3aed 100%);
-      color: #fff; padding: 56px 0 44px;
-      text-align: center; position: relative; overflow: hidden;
-    }
-    .result-header::before {
-      content: '';
-      position: absolute; inset: 0;
-      background:
-        radial-gradient(ellipse at 20% 50%, rgba(244,114,182,.2) 0%, transparent 40%),
-        radial-gradient(ellipse at 80% 40%, rgba(34,211,238,.15) 0%, transparent 40%);
-    }
-    .confetti-row {
-      display: flex; justify-content: center; gap: 10px; font-size: 1.8rem;
-      margin-bottom: 14px; animation: floatIn .6s ease both;
-    }
-    @keyframes floatIn {
-      from { opacity: 0; transform: translateY(-16px); }
-      to   { opacity: 1; transform: translateY(0); }
-    }
-    .pixel-result {
-      font-family: 'Press Start 2P', monospace;
-      font-size: clamp(.85rem, 2.5vw, 1.4rem);
-      color: #fff; line-height: 1.6;
-      text-shadow: 2px 2px 0 rgba(0,0,0,.3);
-    }
-    .pixel-result span { color: var(--yellow); }
-
-    /* Best time card */
-    .best-card {
-      background: linear-gradient(135deg, #14532d, #16a34a, #4ade80);
-      border-radius: 24px; color: #fff; padding: 32px 36px;
-      box-shadow: 0 8px 40px rgba(74,222,128,.3);
-      border: none; position: relative; overflow: hidden;
-    }
-    .best-card::before {
-      content: '🏆';
-      position: absolute; right: -10px; bottom: -20px;
-      font-size: 8rem; opacity: .1;
-    }
-    .best-time-label {
-      font-size: .75rem; font-weight: 900; letter-spacing: .12em;
-      text-transform: uppercase; opacity: .8; margin-bottom: 6px;
-    }
-    .best-time-main {
-      font-family: 'Press Start 2P', monospace;
-      font-size: clamp(1rem, 3vw, 1.5rem); line-height: 1.5;
-    }
-
-    /* Grouped avatars */
-    .group-avatar {
-      width: 56px; height: 56px; border-radius: 50%;
-      display: flex; align-items: center; justify-content: center;
-      font-size: 1.5rem;
-      border: 4px solid #fff;
-      transition: transform .2s;
-    }
-    .group-avatar:hover { transform: scale(1.12) translateY(-4px); }
-
-    /* Heatmap grid */
-    .grid-outer { overflow-x: auto; }
-    #rGrid {
-      border-collapse: separate; border-spacing: 4px; min-width: 480px;
-    }
-    #rGrid thead th {
-      padding: 10px 6px; text-align: center;
-      font-size: .78rem; font-weight: 900; color: var(--p1);
-      background: var(--p4); border-radius: 10px; white-space: nowrap; border: none;
-    }
-    #rGrid thead th:first-child { background: transparent; min-width: 72px; }
-    #rGrid td.time-lbl {
-      font-size: .72rem; font-weight: 800; color: var(--muted);
-      text-align: right; padding-right: 8px; white-space: nowrap;
-      background: transparent; border: none;
-    }
-    #rGrid td.htile {
-      width: 54px; height: 40px; border-radius: 10px; border: 2px solid transparent;
-      transition: transform .12s;
-    }
-    #rGrid td.htile:hover { transform: scale(1.08); }
-
-    .h0 { background: #f3f4f6; border-color: #e5e7eb; }
-    .h1 { background: #dcfce7; border-color: #bbf7d0; }
-    .h2 { background: #86efac; border-color: #4ade80; }
-    .h3 { background: #22c55e; border-color: #16a34a; color:#fff; font-size:.7rem; font-weight:800; text-align:center; line-height:40px; }
-    .h4 {
-      background: var(--p2) !important; border-color: #a78bfa !important;
-      box-shadow: 0 0 0 2px rgba(109,40,217,.25), 0 0 14px rgba(109,40,217,.4) !important;
-      font-size: .65rem; font-weight: 900; color: #fff; text-align: center; line-height: 40px;
-      position: relative;
-    }
-    .h4::after {
-      content: '★';
-      position: absolute; top: 2px; right: 4px; font-size: 9px; color: #c4b5fd;
-    }
-
-    /* Participant table */
-    .part-table th { font-size: .75rem; font-weight: 900; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); background: var(--p4); }
-    .avail-circle { width: 18px; height: 18px; border-radius: 50%; display: inline-block; }
-
-    /* Action buttons */
-    .btn-confirm {
-      background: linear-gradient(135deg, #16a34a, #4ade80);
-      color: #fff; border: none; border-radius: 50px;
-      font-weight: 900; font-size: 1rem; padding: 14px 32px;
-      box-shadow: 0 4px 20px rgba(74,222,128,.35);
-      transition: transform .15s, box-shadow .15s;
-    }
-    .btn-confirm:hover { transform: translateY(-2px); box-shadow: 0 8px 28px rgba(74,222,128,.45); color:#fff; }
-    .btn-share {
-      background: linear-gradient(135deg, var(--p2), var(--pink));
-      color: #fff; border: none; border-radius: 50px;
-      font-weight: 800; font-size: 1rem; padding: 14px 28px;
-      box-shadow: 0 4px 20px rgba(124,58,237,.3);
-      transition: transform .15s;
-    }
-    .btn-share:hover { transform: translateY(-2px); color: #fff; }
-
-    .res-card {
-      background: var(--card); border-radius: 20px;
-      border: 2px solid var(--p4); box-shadow: 0 4px 20px rgba(109,40,217,.07);
-    }
-    .res-card-hdr {
-      background: linear-gradient(90deg, var(--p4), #fce7f3);
-      padding: 13px 22px; border-bottom: 2px solid #ede9fe;
-      font-weight: 900; font-size: .8rem; color: var(--p2);
-      text-transform: uppercase; letter-spacing: .08em;
-      border-radius: 18px 18px 0 0;
-    }
-    .res-card-body { padding: 22px; }
-
-    footer { background: #0f0e1a; color: rgba(255,255,255,.4); }
-  </style>
-</head>
-<body>
-
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg sm-navbar">
-    <div class="container">
-      <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
-      <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="mainNav">
-        <ul class="navbar-nav me-auto gap-1">
-          <li class="nav-item"><a class="nav-link" href="index.html"><i class="bi bi-house-fill me-1"></i>Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="dashboard.html"><i class="bi bi-grid-fill me-1"></i>My Space</a></li>
-          <li class="nav-item"><a class="nav-link" href="create-event.html"><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a></li>
-        </ul>
-        <div class="d-flex gap-2 mt-2 mt-lg-0">
-          <a href="#" class="btn-nav-outline">Login</a>
-          <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SmartMeet – Best Time Found!</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg sm-navbar">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
+        <button
+          class="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNav"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav me-auto gap-1">
+            <li class="nav-item">
+              <a class="nav-link" href="index.html"
+                ><i class="bi bi-house-fill me-1"></i>Home</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="dashboard.html"
+                ><i class="bi bi-grid-fill me-1"></i>My Space</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="schedule.html"
+                ><i class="bi bi-calendar-week-fill me-1"></i>My Schedule</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="create-event.html"
+                ><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a
+              >
+            </li>
+          </ul>
+          <div class="d-flex gap-2 mt-2 mt-lg-0">
+            <a href="#" class="btn-nav-outline">Login</a>
+            <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+          </div>
         </div>
       </div>
-    </div>
-  </nav>
+    </nav>
 
-  <!-- Result Header -->
-  <div class="result-header">
-    <div class="container position-relative">
-      <div class="confetti-row">🎉 🏆 ✨ 🎊 ⭐</div>
-      <h2 class="pixel-result mb-2">Best Time <span>Found!</span></h2>
-      <p style="opacity:.8;font-size:.95rem;">SmartMeet has found the perfect slot for your team.</p>
-
-      <!-- Grouped avatars -->
-      <div class="d-flex justify-content-center mt-4 mb-2">
-        <div style="display:flex;align-items:center;">
-          <div class="group-avatar" style="background:linear-gradient(135deg,#f472b6,#a78bfa);z-index:4;">🐱</div>
-          <div class="group-avatar" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);margin-left:-14px;z-index:3;">🦊</div>
-          <div class="group-avatar" style="background:linear-gradient(135deg,#4ade80,#0ea5e9);margin-left:-14px;z-index:2;">🐻</div>
-          <div class="group-avatar" style="background:linear-gradient(135deg,#fbbf24,#f472b6);margin-left:-14px;z-index:1;">🐼</div>
-          <div class="group-avatar" style="background:rgba(255,255,255,.15);border:3px dashed rgba(255,255,255,.4);margin-left:-14px;z-index:0;color:rgba(255,255,255,.6);font-size:1rem;">+1</div>
+    <!-- Result Header -->
+    <div class="result-header">
+      <div class="container position-relative">
+        <div class="confetti-row">🎉 🏆 ✨ 🎊 ⭐</div>
+        <h2 class="pixel-result mb-2">Best Time <span>Found!</span></h2>
+        <p style="opacity: 0.8; font-size: 0.95rem">
+          SmartMeet has found the perfect slot for your team.
+        </p>
+        <div class="d-flex justify-content-center mt-4 mb-2">
+          <div style="display: flex; align-items: center">
+            <div
+              class="group-avatar"
+              style="
+                background: linear-gradient(135deg, #f472b6, #a78bfa);
+                z-index: 4;
+              "
+            >
+              🐱
+            </div>
+            <div
+              class="group-avatar"
+              style="
+                background: linear-gradient(135deg, #22d3ee, #6d28d9);
+                margin-left: -14px;
+                z-index: 3;
+              "
+            >
+              🦊
+            </div>
+            <div
+              class="group-avatar"
+              style="
+                background: linear-gradient(135deg, #4ade80, #0ea5e9);
+                margin-left: -14px;
+                z-index: 2;
+              "
+            >
+              🐻
+            </div>
+            <div
+              class="group-avatar"
+              style="
+                background: linear-gradient(135deg, #fbbf24, #f472b6);
+                margin-left: -14px;
+                z-index: 1;
+              "
+            >
+              🐼
+            </div>
+            <div
+              class="group-avatar"
+              style="
+                background: rgba(255, 255, 255, 0.15);
+                border: 3px dashed rgba(255, 255, 255, 0.4);
+                margin-left: -14px;
+                z-index: 0;
+                color: rgba(255, 255, 255, 0.6);
+                font-size: 1rem;
+              "
+            >
+              +1
+            </div>
+          </div>
         </div>
-      </div>
-      <p style="opacity:.75;font-size:.85rem;font-weight:700;">4 of 5 participants are free! 🎯</p>
-    </div>
-  </div>
-
-  <div class="container py-5" style="max-width:900px;">
-
-    <!-- Best Time Card -->
-    <div class="best-card mb-4">
-      <div class="row align-items-center g-3">
-        <div class="col-md-8">
-          <div class="best-time-label">🏆 Recommended Meeting Time</div>
-          <div class="best-time-main">Wednesday 8 May</div>
-          <div class="best-time-main" style="color:#bbf7d0;">10:00 AM – 11:00 AM</div>
-          <p class="mt-3 mb-0" style="opacity:.9;font-size:.95rem;font-weight:700;">
-            ✅ Everyone is available at this time! &nbsp;·&nbsp; 0 conflicts &nbsp;·&nbsp; 1 hour
-          </p>
-        </div>
-        <div class="col-md-4 d-flex flex-column gap-2">
-          <button class="btn-confirm w-100">📅 Confirm This Time</button>
-          <button class="btn-share w-100">🔗 Share with Team</button>
-        </div>
+        <p style="opacity: 0.75; font-size: 0.85rem; font-weight: 700">
+          4 of 5 participants are free! 🎯
+        </p>
       </div>
     </div>
 
-    <!-- Event Summary -->
-    <div class="res-card mb-4">
-      <div class="res-card-hdr">📋 Event Summary</div>
-      <div class="res-card-body">
-        <div class="row g-3 small">
-          <div class="col-sm-4"><div class="fw-900 mb-1">Event</div><div class="text-muted">Team Sprint Planning 🚀</div></div>
-          <div class="col-sm-4"><div class="fw-900 mb-1">Organiser</div><div class="text-muted">Jane Smith 🐱</div></div>
-          <div class="col-sm-4"><div class="fw-900 mb-1">Duration</div><div class="text-muted">1 hour</div></div>
-          <div class="col-sm-4"><div class="fw-900 mb-1">Date Range</div><div class="text-muted">6–10 May 2024</div></div>
-          <div class="col-sm-4"><div class="fw-900 mb-1">Time Window</div><div class="text-muted">9:00 AM – 5:00 PM</div></div>
-          <div class="col-sm-4"><div class="fw-900 mb-1">Responses</div><div class="text-muted">4 / 5 participants</div></div>
+    <div class="container py-5" style="max-width: 900px">
+      <!-- Best Time Card -->
+      <div class="best-card mb-4">
+        <div class="row align-items-center g-3">
+          <div class="col-md-8">
+            <div class="best-time-label">🏆 Recommended Meeting Time</div>
+            <div class="best-time-main">Wednesday 8 May</div>
+            <div class="best-time-main" style="color: #bbf7d0">
+              10:00 AM – 11:00 AM
+            </div>
+            <p
+              class="mt-3 mb-0"
+              style="opacity: 0.9; font-size: 0.95rem; font-weight: 700"
+            >
+              ✅ 4 of 5 available &nbsp;·&nbsp; 0 conflicts &nbsp;·&nbsp; 1 hour
+            </p>
+          </div>
+          <div class="col-md-4 d-flex flex-column gap-2">
+            <button class="btn-confirm w-100">📅 Confirm This Time</button>
+            <button class="btn-share w-100">🔗 Share with Team</button>
+          </div>
         </div>
+      </div>
+
+      <!-- Runner-up Slots -->
+      <p class="section-label">🥈 Other Good Options</p>
+      <div class="d-flex flex-column gap-3 mb-5">
+        <div class="runnerup-card">
+          <div class="runnerup-rank rank-2">2nd</div>
+          <div class="flex-grow-1">
+            <div class="runnerup-time">Thursday 9 May · 9:00 AM – 10:00 AM</div>
+            <div class="runnerup-meta">3 of 5 available · 1 conflict</div>
+          </div>
+          <div class="score-bar-wrap">
+            <div
+              class="d-flex justify-content-between mb-1"
+              style="font-size: 0.72rem; font-weight: 800; color: var(--muted)"
+            >
+              <span>Score</span><span>3 / 5</span>
+            </div>
+            <div class="score-bar-track">
+              <div
+                class="score-bar-fill"
+                style="
+                  width: 75%;
+                  background: linear-gradient(90deg, #fbbf24, #f59e0b);
+                "
+              ></div>
+            </div>
+          </div>
+          <button
+            class="btn-confirm"
+            style="font-size: 0.82rem; padding: 8px 18px"
+          >
+            Select
+          </button>
+        </div>
+
+        <div class="runnerup-card">
+          <div class="runnerup-rank rank-3">3rd</div>
+          <div class="flex-grow-1">
+            <div class="runnerup-time">Monday 6 May · 1:00 PM – 2:00 PM</div>
+            <div class="runnerup-meta">3 of 5 available · 2 conflicts</div>
+          </div>
+          <div class="score-bar-wrap">
+            <div
+              class="d-flex justify-content-between mb-1"
+              style="font-size: 0.72rem; font-weight: 800; color: var(--muted)"
+            >
+              <span>Score</span><span>3 / 5</span>
+            </div>
+            <div class="score-bar-track">
+              <div
+                class="score-bar-fill"
+                style="
+                  width: 60%;
+                  background: linear-gradient(90deg, var(--p2), var(--p3));
+                "
+              ></div>
+            </div>
+          </div>
+          <button
+            class="btn-confirm"
+            style="
+              font-size: 0.82rem;
+              padding: 8px 18px;
+              background: linear-gradient(135deg, var(--p2), var(--pink));
+              box-shadow: none;
+            "
+          >
+            Select
+          </button>
+        </div>
+      </div>
+
+      <!-- Event Summary -->
+      <div class="res-card mb-4">
+        <div class="res-card-hdr">📋 Event Summary</div>
+        <div class="res-card-body">
+          <div class="row g-3 small">
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Event</div>
+              <div class="text-muted">Team Sprint Planning 🚀</div>
+            </div>
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Organiser</div>
+              <div class="text-muted">Jane Smith 🐱</div>
+            </div>
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Duration</div>
+              <div class="text-muted">1 hour</div>
+            </div>
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Date Range</div>
+              <div class="text-muted">6–10 May 2024</div>
+            </div>
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Time Window</div>
+              <div class="text-muted">9:00 AM – 5:00 PM</div>
+            </div>
+            <div class="col-sm-4">
+              <div class="fw-900 mb-1">Responses</div>
+              <div class="text-muted">4 / 5 participants</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Heatmap -->
+      <div class="res-card mb-4">
+        <div class="res-card-hdr">🔥 Availability Heatmap</div>
+        <div class="res-card-body">
+          <div
+            class="d-flex gap-3 small text-muted mb-3 flex-wrap align-items-center"
+          >
+            <span>Darker = more people free &nbsp;|&nbsp;</span>
+            <span
+              ><span
+                style="
+                  background: #f3f4f6;
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border-radius: 4px;
+                  vertical-align: middle;
+                "
+              ></span>
+              0</span
+            >
+            <span
+              ><span
+                style="
+                  background: #dcfce7;
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border-radius: 4px;
+                  vertical-align: middle;
+                "
+              ></span>
+              1</span
+            >
+            <span
+              ><span
+                style="
+                  background: #86efac;
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border-radius: 4px;
+                  vertical-align: middle;
+                "
+              ></span>
+              2</span
+            >
+            <span
+              ><span
+                style="
+                  background: #22c55e;
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border-radius: 4px;
+                  vertical-align: middle;
+                "
+              ></span>
+              3</span
+            >
+            <span
+              ><span
+                style="
+                  background: var(--p2);
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border-radius: 4px;
+                  vertical-align: middle;
+                "
+              ></span>
+              Best ★</span
+            >
+          </div>
+          <div class="grid-outer">
+            <table class="av-table" id="rGrid">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>
+                    <div>Mon</div>
+                    <div style="opacity: 0.65; font-weight: 600">6 May</div>
+                  </th>
+                  <th>
+                    <div>Tue</div>
+                    <div style="opacity: 0.65; font-weight: 600">7 May</div>
+                  </th>
+                  <th>
+                    <div>Wed</div>
+                    <div style="opacity: 0.65; font-weight: 600">8 May</div>
+                  </th>
+                  <th>
+                    <div>Thu</div>
+                    <div style="opacity: 0.65; font-weight: 600">9 May</div>
+                  </th>
+                  <th>
+                    <div>Fri</div>
+                    <div style="opacity: 0.65; font-weight: 600">10 May</div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="hour-start">
+                  <td class="time-lbl">9:00 AM</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h0"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">9:30 AM</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">10:00 AM</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h4">4★</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">10:30 AM</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">11:00 AM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">11:30 AM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">12:00 PM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h2">2</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">12:30 PM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h2">2</td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">1:00 PM</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">1:30 PM</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">2:00 PM</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">2:30 PM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h0"></td>
+                  <td class="htile h3">3</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">3:00 PM</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h3">3</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">3:30 PM</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h3">3</td>
+                </tr>
+                <tr class="hour-start">
+                  <td class="time-lbl">4:00 PM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+                <tr>
+                  <td class="time-lbl">4:30 PM</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h2">2</td>
+                  <td class="htile h0"></td>
+                  <td class="htile h1">1</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- Participant Overview -->
+      <div class="res-card mb-5">
+        <div class="res-card-hdr">👥 Participant Overview</div>
+        <div class="res-card-body p-0">
+          <div class="table-responsive">
+            <table class="table align-middle mb-0 part-table">
+              <thead>
+                <tr>
+                  <th class="ps-4">Player</th>
+                  <th>Status</th>
+                  <th>Wed 8 May · 10 AM</th>
+                  <th>Slots Free</th>
+                  <th>Responded</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="ps-4">
+                    <div class="d-flex align-items-center gap-2">
+                      <div
+                        style="
+                          width: 36px;
+                          height: 36px;
+                          border-radius: 50%;
+                          background: linear-gradient(135deg, #f472b6, #a78bfa);
+                          display: flex;
+                          align-items: center;
+                          justify-content: center;
+                          font-size: 1.1rem;
+                        "
+                      >
+                        🐱
+                      </div>
+                      <div>
+                        <div class="fw-800">Jane Smith</div>
+                        <div class="text-muted" style="font-size: 0.72rem">
+                          Organiser
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      class="badge rounded-pill"
+                      style="
+                        background: #d1fae5;
+                        color: #065f46;
+                        font-size: 0.72rem;
+                      "
+                      >✅ Available</span
+                    >
+                  </td>
+                  <td>
+                    <span
+                      class="avail-circle"
+                      style="background: #4ade80"
+                    ></span>
+                  </td>
+                  <td>
+                    <span class="fw-700">28</span
+                    ><span class="text-muted small"> / 40</span>
+                  </td>
+                  <td>
+                    <i class="bi bi-check-circle-fill text-success me-1"></i
+                    ><span class="fw-700 small">Yes</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="ps-4">
+                    <div class="d-flex align-items-center gap-2">
+                      <div
+                        style="
+                          width: 36px;
+                          height: 36px;
+                          border-radius: 50%;
+                          background: linear-gradient(135deg, #22d3ee, #6d28d9);
+                          display: flex;
+                          align-items: center;
+                          justify-content: center;
+                          font-size: 1.1rem;
+                        "
+                      >
+                        🦊
+                      </div>
+                      <div>
+                        <div class="fw-800">FoxDev</div>
+                        <div class="text-muted" style="font-size: 0.72rem">
+                          Participant
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      class="badge rounded-pill"
+                      style="
+                        background: #d1fae5;
+                        color: #065f46;
+                        font-size: 0.72rem;
+                      "
+                      >✅ Available</span
+                    >
+                  </td>
+                  <td>
+                    <span
+                      class="avail-circle"
+                      style="background: #4ade80"
+                    ></span>
+                  </td>
+                  <td>
+                    <span class="fw-700">22</span
+                    ><span class="text-muted small"> / 40</span>
+                  </td>
+                  <td>
+                    <i class="bi bi-check-circle-fill text-success me-1"></i
+                    ><span class="fw-700 small">Yes</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="ps-4">
+                    <div class="d-flex align-items-center gap-2">
+                      <div
+                        style="
+                          width: 36px;
+                          height: 36px;
+                          border-radius: 50%;
+                          background: linear-gradient(135deg, #4ade80, #0ea5e9);
+                          display: flex;
+                          align-items: center;
+                          justify-content: center;
+                          font-size: 1.1rem;
+                        "
+                      >
+                        🐻
+                      </div>
+                      <div>
+                        <div class="fw-800">BearCo</div>
+                        <div class="text-muted" style="font-size: 0.72rem">
+                          Participant
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      class="badge rounded-pill"
+                      style="
+                        background: #d1fae5;
+                        color: #065f46;
+                        font-size: 0.72rem;
+                      "
+                      >✅ Available</span
+                    >
+                  </td>
+                  <td>
+                    <span
+                      class="avail-circle"
+                      style="background: #4ade80"
+                    ></span>
+                  </td>
+                  <td>
+                    <span class="fw-700">31</span
+                    ><span class="text-muted small"> / 40</span>
+                  </td>
+                  <td>
+                    <i class="bi bi-check-circle-fill text-success me-1"></i
+                    ><span class="fw-700 small">Yes</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="ps-4">
+                    <div class="d-flex align-items-center gap-2">
+                      <div
+                        style="
+                          width: 36px;
+                          height: 36px;
+                          border-radius: 50%;
+                          background: linear-gradient(135deg, #fbbf24, #f472b6);
+                          display: flex;
+                          align-items: center;
+                          justify-content: center;
+                          font-size: 1.1rem;
+                        "
+                      >
+                        🐼
+                      </div>
+                      <div>
+                        <div class="fw-800">PandaX</div>
+                        <div class="text-muted" style="font-size: 0.72rem">
+                          Participant
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      class="badge rounded-pill"
+                      style="
+                        background: #d1fae5;
+                        color: #065f46;
+                        font-size: 0.72rem;
+                      "
+                      >✅ Available</span
+                    >
+                  </td>
+                  <td>
+                    <span
+                      class="avail-circle"
+                      style="background: #4ade80"
+                    ></span>
+                  </td>
+                  <td>
+                    <span class="fw-700">19</span
+                    ><span class="text-muted small"> / 40</span>
+                  </td>
+                  <td>
+                    <i class="bi bi-check-circle-fill text-success me-1"></i
+                    ><span class="fw-700 small">Yes</span>
+                  </td>
+                </tr>
+                <tr class="table-light">
+                  <td class="ps-4">
+                    <div class="d-flex align-items-center gap-2">
+                      <div
+                        style="
+                          width: 36px;
+                          height: 36px;
+                          border-radius: 50%;
+                          background: #e5e7eb;
+                          display: flex;
+                          align-items: center;
+                          justify-content: center;
+                          font-size: 1.1rem;
+                        "
+                      >
+                        ❓
+                      </div>
+                      <div>
+                        <div class="fw-800 text-muted">Sam Patel</div>
+                        <div class="text-muted" style="font-size: 0.72rem">
+                          Participant
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <span
+                      class="badge rounded-pill"
+                      style="
+                        background: #fef3c7;
+                        color: #92400e;
+                        font-size: 0.72rem;
+                      "
+                      >⏳ Pending</span
+                    >
+                  </td>
+                  <td><span class="text-muted">–</span></td>
+                  <td><span class="text-muted">–</span></td>
+                  <td>
+                    <div class="d-flex align-items-center gap-2">
+                      <i class="bi bi-clock text-warning"></i>
+                      <span class="fw-700 small text-muted">No</span>
+                      <button class="btn-remind">📩 Remind</button>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action buttons -->
+      <div class="d-flex gap-3 flex-wrap justify-content-center mb-3">
+        <button class="btn-confirm">🎉 Confirm Wednesday 8 May</button>
+        <button class="btn-share">📩 Notify Participants</button>
+      </div>
+      <div class="d-flex justify-content-center">
+        <a
+          href="dashboard.html"
+          class="btn btn-outline-secondary rounded-pill fw-700 px-4 py-2"
+        >
+          <i class="bi bi-arrow-left me-2"></i>Back to My Space
+        </a>
       </div>
     </div>
 
-    <!-- Heatmap -->
-    <div class="res-card mb-4">
-      <div class="res-card-hdr">🔥 Availability Heatmap</div>
-      <div class="res-card-body">
-        <div class="d-flex gap-3 small text-muted mb-3 flex-wrap align-items-center">
-          <span>Darker = more people free &nbsp;|&nbsp;</span>
-          <span><span style="background:#f3f4f6;display:inline-block;width:14px;height:14px;border-radius:4px;vertical-align:middle;"></span> 0</span>
-          <span><span style="background:#dcfce7;display:inline-block;width:14px;height:14px;border-radius:4px;vertical-align:middle;"></span> 1</span>
-          <span><span style="background:#86efac;display:inline-block;width:14px;height:14px;border-radius:4px;vertical-align:middle;"></span> 2</span>
-          <span><span style="background:#22c55e;display:inline-block;width:14px;height:14px;border-radius:4px;vertical-align:middle;"></span> 3</span>
-          <span><span style="background:var(--p2);display:inline-block;width:14px;height:14px;border-radius:4px;vertical-align:middle;"></span> Best ★</span>
-        </div>
-        <div class="grid-outer">
-          <table id="rGrid">
-            <thead>
-              <tr>
-                <th></th>
-                <th><div>Mon</div><div style="opacity:.65;font-weight:600;">6 May</div></th>
-                <th><div>Tue</div><div style="opacity:.65;font-weight:600;">7 May</div></th>
-                <th><div>Wed</div><div style="opacity:.65;font-weight:600;">8 May</div></th>
-                <th><div>Thu</div><div style="opacity:.65;font-weight:600;">9 May</div></th>
-                <th><div>Fri</div><div style="opacity:.65;font-weight:600;">10 May</div></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr><td class="time-lbl">9:00 AM</td>  <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h2">2</td> <td class="htile h3">3</td> <td class="htile h0"></td></tr>
-              <tr><td class="time-lbl">9:30 AM</td>  <td class="htile h3">3</td> <td class="htile h3">3</td> <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h0"></td></tr>
-              <tr><td class="time-lbl">10:00 AM</td> <td class="htile h2">2</td> <td class="htile h1">1</td> <td class="htile h4">4★</td> <td class="htile h3">3</td> <td class="htile h2">2</td></tr>
-              <tr><td class="time-lbl">10:30 AM</td> <td class="htile h1">1</td> <td class="htile h1">1</td> <td class="htile h3">3</td> <td class="htile h3">3</td> <td class="htile h2">2</td></tr>
-              <tr><td class="time-lbl">11:00 AM</td> <td class="htile h0"></td>  <td class="htile h2">2</td> <td class="htile h3">3</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-              <tr><td class="time-lbl">11:30 AM</td> <td class="htile h0"></td>  <td class="htile h2">2</td> <td class="htile h3">3</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-              <tr><td class="time-lbl">12:00 PM</td> <td class="htile h0"></td>  <td class="htile h1">1</td> <td class="htile h1">1</td> <td class="htile h2">2</td> <td class="htile h2">2</td></tr>
-              <tr><td class="time-lbl">12:30 PM</td> <td class="htile h0"></td>  <td class="htile h1">1</td> <td class="htile h1">1</td> <td class="htile h2">2</td> <td class="htile h2">2</td></tr>
-              <tr><td class="time-lbl">1:00 PM</td>  <td class="htile h2">2</td> <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-              <tr><td class="time-lbl">1:30 PM</td>  <td class="htile h3">3</td> <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-              <tr><td class="time-lbl">2:00 PM</td>  <td class="htile h1">1</td> <td class="htile h0"></td>  <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h0"></td></tr>
-              <tr><td class="time-lbl">2:30 PM</td>  <td class="htile h0"></td>  <td class="htile h0"></td>  <td class="htile h3">3</td> <td class="htile h2">2</td> <td class="htile h0"></td></tr>
-              <tr><td class="time-lbl">3:00 PM</td>  <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td> <td class="htile h1">1</td> <td class="htile h3">3</td></tr>
-              <tr><td class="time-lbl">3:30 PM</td>  <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td> <td class="htile h0"></td>  <td class="htile h3">3</td></tr>
-              <tr><td class="time-lbl">4:00 PM</td>  <td class="htile h0"></td>  <td class="htile h2">2</td> <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-              <tr><td class="time-lbl">4:30 PM</td>  <td class="htile h0"></td>  <td class="htile h2">2</td> <td class="htile h2">2</td> <td class="htile h0"></td>  <td class="htile h1">1</td></tr>
-            </tbody>
-          </table>
-        </div>
+    <footer class="py-4 text-center">
+      <div class="container">
+        <p class="mb-0 small">
+          © 2026 SmartMeet · CITS3403 Project · University of Western Australia
+        </p>
       </div>
-    </div>
+    </footer>
 
-    <!-- Participant Overview -->
-    <div class="res-card mb-5">
-      <div class="res-card-hdr">👥 Participant Overview</div>
-      <div class="res-card-body p-0">
-        <div class="table-responsive">
-          <table class="table align-middle mb-0 part-table">
-            <thead>
-              <tr>
-                <th class="ps-4">Player</th>
-                <th>Status</th>
-                <th>Wed 8 May · 10 AM</th>
-                <th>Slots Free</th>
-                <th>Responded</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td class="ps-4">
-                  <div class="d-flex align-items-center gap-2">
-                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#f472b6,#a78bfa);display:flex;align-items:center;justify-content:center;font-size:1.1rem;">🐱</div>
-                    <div><div class="fw-800">Jane Smith</div><div class="text-muted" style="font-size:.72rem;">Organiser</div></div>
-                  </div>
-                </td>
-                <td><span class="badge rounded-pill" style="background:#d1fae5;color:#065f46;font-size:.72rem;">✅ Available</span></td>
-                <td><span class="avail-circle" style="background:#4ade80;"></span></td>
-                <td><span class="fw-700">28</span><span class="text-muted small"> / 40</span></td>
-                <td><i class="bi bi-check-circle-fill text-success me-1"></i><span class="fw-700 small">Yes</span></td>
-              </tr>
-              <tr>
-                <td class="ps-4">
-                  <div class="d-flex align-items-center gap-2">
-                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#22d3ee,#6d28d9);display:flex;align-items:center;justify-content:center;font-size:1.1rem;">🦊</div>
-                    <div><div class="fw-800">FoxDev</div><div class="text-muted" style="font-size:.72rem;">Participant</div></div>
-                  </div>
-                </td>
-                <td><span class="badge rounded-pill" style="background:#d1fae5;color:#065f46;font-size:.72rem;">✅ Available</span></td>
-                <td><span class="avail-circle" style="background:#4ade80;"></span></td>
-                <td><span class="fw-700">22</span><span class="text-muted small"> / 40</span></td>
-                <td><i class="bi bi-check-circle-fill text-success me-1"></i><span class="fw-700 small">Yes</span></td>
-              </tr>
-              <tr>
-                <td class="ps-4">
-                  <div class="d-flex align-items-center gap-2">
-                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#4ade80,#0ea5e9);display:flex;align-items:center;justify-content:center;font-size:1.1rem;">🐻</div>
-                    <div><div class="fw-800">BearCo</div><div class="text-muted" style="font-size:.72rem;">Participant</div></div>
-                  </div>
-                </td>
-                <td><span class="badge rounded-pill" style="background:#d1fae5;color:#065f46;font-size:.72rem;">✅ Available</span></td>
-                <td><span class="avail-circle" style="background:#4ade80;"></span></td>
-                <td><span class="fw-700">31</span><span class="text-muted small"> / 40</span></td>
-                <td><i class="bi bi-check-circle-fill text-success me-1"></i><span class="fw-700 small">Yes</span></td>
-              </tr>
-              <tr>
-                <td class="ps-4">
-                  <div class="d-flex align-items-center gap-2">
-                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#fbbf24,#f472b6);display:flex;align-items:center;justify-content:center;font-size:1.1rem;">🐼</div>
-                    <div><div class="fw-800">PandaX</div><div class="text-muted" style="font-size:.72rem;">Participant</div></div>
-                  </div>
-                </td>
-                <td><span class="badge rounded-pill" style="background:#d1fae5;color:#065f46;font-size:.72rem;">✅ Available</span></td>
-                <td><span class="avail-circle" style="background:#4ade80;"></span></td>
-                <td><span class="fw-700">19</span><span class="text-muted small"> / 40</span></td>
-                <td><i class="bi bi-check-circle-fill text-success me-1"></i><span class="fw-700 small">Yes</span></td>
-              </tr>
-              <tr class="table-light">
-                <td class="ps-4">
-                  <div class="d-flex align-items-center gap-2">
-                    <div style="width:36px;height:36px;border-radius:50%;background:#e5e7eb;display:flex;align-items:center;justify-content:center;font-size:1.1rem;">❓</div>
-                    <div><div class="fw-800 text-muted">Sam Patel</div><div class="text-muted" style="font-size:.72rem;">Participant</div></div>
-                  </div>
-                </td>
-                <td><span class="badge rounded-pill" style="background:#fef3c7;color:#92400e;font-size:.72rem;">⏳ Pending</span></td>
-                <td><span class="text-muted">–</span></td>
-                <td><span class="text-muted">–</span></td>
-                <td><i class="bi bi-clock text-warning me-1"></i><span class="fw-700 small text-muted">No</span></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <!-- Action buttons -->
-    <div class="d-flex gap-3 flex-wrap justify-content-center">
-      <button class="btn-confirm">🎉 Confirm Wednesday 8 May</button>
-      <button class="btn-share">📩 Notify Participants</button>
-      <a href="dashboard.html" class="btn btn-outline-secondary rounded-pill fw-700 px-4 py-3">
-        <i class="bi bi-arrow-left me-2"></i>Back to My Space
-      </a>
-    </div>
-
-  </div>
-
-  <!-- Footer -->
-  <footer class="py-4 text-center">
-    <div class="container">
-      <p class="mb-0 small">© 2024 SmartMeet · CITS3403 Project · University of Western Australia</p>
-    </div>
-  </footer>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
 </html>

--- a/schedule.html
+++ b/schedule.html
@@ -1,0 +1,612 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SmartMeet – My Schedule</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Press+Start+2P&display=swap"
+      rel="stylesheet"
+    />
+    <link href="style.css" rel="stylesheet" />
+  </head>
+  <body>
+    <!-- Navbar -->
+    <nav class="navbar navbar-expand-lg sm-navbar">
+      <div class="container">
+        <a class="navbar-brand" href="index.html">Smart<span>Meet</span></a>
+        <button
+          class="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#mainNav"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav me-auto gap-1">
+            <li class="nav-item">
+              <a class="nav-link" href="index.html"
+                ><i class="bi bi-house-fill me-1"></i>Home</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="dashboard.html"
+                ><i class="bi bi-grid-fill me-1"></i>My Space</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link active" href="schedule.html"
+                ><i class="bi bi-calendar-week-fill me-1"></i>My Schedule</a
+              >
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="create-event.html"
+                ><i class="bi bi-plus-circle-fill me-1"></i>Create Room</a
+              >
+            </li>
+          </ul>
+          <div class="d-flex gap-2 mt-2 mt-lg-0">
+            <a href="#" class="btn-nav-outline">Login</a>
+            <a href="create-event.html" class="btn-nav-pink">▶ Enter</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="page-header">
+      <div class="container position-relative text-center">
+        <div class="page-header-icon">🗓️</div>
+        <h2 class="pixel-title mb-2">My Schedule</h2>
+        <p
+          style="
+            opacity: 0.8;
+            font-size: 0.95rem;
+            max-width: 520px;
+            margin: 0 auto;
+          "
+        >
+          Set your general weekly availability. SmartMeet will use this to
+          pre-fill your responses when you're invited to a room.
+        </p>
+      </div>
+    </div>
+
+    <div class="container py-5" style="max-width: 1000px">
+      <div class="row g-4">
+        <!-- Left: main content -->
+        <div class="col-lg-8">
+          <!-- Import Section -->
+          <div class="sm-card mb-4">
+            <div class="sm-card-header">
+              <i class="bi bi-box-arrow-in-down"></i> Import Your Calendar
+            </div>
+            <div class="sm-card-body">
+              <div class="import-note mb-4">
+                <i
+                  class="bi bi-info-circle-fill"
+                  style="font-size: 1.1rem; flex-shrink: 0; margin-top: 1px"
+                ></i>
+                <span
+                  >Importing will auto-fill your schedule below. Your busy times
+                  from the calendar will be marked as <strong>Busy</strong>. You
+                  can always edit them manually afterwards.</span
+                >
+              </div>
+
+              <div class="import-grid">
+                <div class="import-card google">
+                  <div class="import-logo">
+                    <img
+                      src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Google_Calendar_icon_%282020%29.svg"
+                      width="32"
+                      height="32"
+                      alt="Google Calendar"
+                      onerror="this.replaceWith(document.createTextNode('📅'))"
+                    />
+                  </div>
+                  <div class="import-name">Google Calendar</div>
+                  <div class="import-desc">
+                    Sync from your Google account automatically
+                  </div>
+                  <span class="import-btn">Connect</span>
+                </div>
+                <div class="import-card apple">
+                  <div class="import-logo">
+                    <img
+                      src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Apple_Calendar_icon.png"
+                      width="32"
+                      height="32"
+                      alt="Apple Calendar"
+                      onerror="this.replaceWith(document.createTextNode('🍎'))"
+                    />
+                  </div>
+                  <div class="import-name">Apple Calendar</div>
+                  <div class="import-desc">
+                    Import via .ics file from iCal or iPhone
+                  </div>
+                  <span class="import-btn">Import .ics</span>
+                </div>
+                <div class="import-card outlook">
+                  <div class="import-logo">
+                    <img
+                      src="https://upload.wikimedia.org/wikipedia/commons/d/df/Microsoft_Office_Outlook_%282018%E2%80%93present%29.svg"
+                      width="32"
+                      height="32"
+                      alt="Outlook"
+                      onerror="this.replaceWith(document.createTextNode('📧'))"
+                    />
+                  </div>
+                  <div class="import-name">Microsoft Outlook</div>
+                  <div class="import-desc">
+                    Sync from your Microsoft 365 account
+                  </div>
+                  <span class="import-btn">Connect</span>
+                </div>
+                <div class="import-card cas">
+                  <div class="import-logo" style="font-size: 1.5rem">🎓</div>
+                  <div class="import-name">UWA CAS</div>
+                  <div class="import-desc">
+                    Import your class timetable from the Class Allocation System
+                  </div>
+                  <span class="import-btn">Import Timetable</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Schedule Grid -->
+          <div class="sm-card">
+            <div
+              class="sm-card-header"
+              style="justify-content: space-between; flex-wrap: wrap; gap: 10px"
+            >
+              <span
+                ><i class="bi bi-grid-3x3-gap me-2"></i>Weekly
+                Availability</span
+              >
+              <div class="d-flex gap-3 flex-wrap align-items-center">
+                <span class="legend-chip"
+                  ><span
+                    class="legend-swatch t-free"
+                    style="border: 2px solid #86efac"
+                  ></span
+                  >Free</span
+                >
+                <span class="legend-chip"
+                  ><span
+                    class="legend-swatch t-maybe"
+                    style="border: 2px solid #fde047"
+                  ></span
+                  >Maybe</span
+                >
+                <span class="legend-chip"
+                  ><span
+                    class="legend-swatch t-busy"
+                    style="border: 2px solid #fca5a5"
+                  ></span
+                  >Busy</span
+                >
+                <span class="legend-chip"
+                  ><span
+                    class="legend-swatch t-empty"
+                    style="border: 2px solid #e5e7eb"
+                  ></span
+                  >Not set</span
+                >
+              </div>
+            </div>
+            <div class="sm-card-body">
+              <div class="time-filter mb-3">
+                <span>Show hours:</span>
+                <select>
+                  <option>6:00 AM</option>
+                  <option selected>8:00 AM</option>
+                  <option>9:00 AM</option>
+                </select>
+                <span>to</span>
+                <select>
+                  <option>6:00 PM</option>
+                  <option selected>8:00 PM</option>
+                  <option>10:00 PM</option>
+                </select>
+                <span class="ms-auto text-muted" style="font-size: 0.75rem"
+                  >Click a tile to cycle: Empty → Free → Maybe → Busy →
+                  Empty</span
+                >
+              </div>
+
+              <div class="grid-outer">
+                <table class="av-table" id="schedGrid">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th>Mon</th>
+                      <th>Tue</th>
+                      <th>Wed</th>
+                      <th>Thu</th>
+                      <th>Fri</th>
+                      <th style="color: var(--pink)">Sat</th>
+                      <th style="color: var(--pink)">Sun</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="hour-start">
+                      <td class="time-lbl">8:00 AM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">8:30 AM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">9:00 AM</td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">9:30 AM</td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">10:00 AM</td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">10:30 AM</td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">11:00 AM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">11:30 AM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">12:00 PM</td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-maybe"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">12:30 PM</td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-maybe"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">1:00 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">1:30 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">2:00 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">2:30 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">3:00 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">3:30 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-busy"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">4:00 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">4:30 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">5:00 PM</td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">5:30 PM</td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-maybe"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">6:00 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">6:30 PM</td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr class="hour-start">
+                      <td class="time-lbl">7:00 PM</td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                    <tr>
+                      <td class="time-lbl">7:30 PM</td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-free"></td>
+                      <td class="tile t-empty"></td>
+                      <td class="tile t-empty"></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: sidebar -->
+        <div class="col-lg-4">
+          <div class="sm-card mb-4">
+            <div class="sm-card-header">
+              <i class="bi bi-floppy me-2"></i>Save Schedule
+            </div>
+            <div class="sm-card-body">
+              <p class="text-muted small fw-700 mb-3">
+                Your schedule is used to pre-fill your availability when you're
+                invited to a room. Keep it up to date!
+              </p>
+              <div class="mb-3">
+                <span class="saved-badge"
+                  ><i class="bi bi-check-circle-fill"></i> Last saved: Today,
+                  9:14 AM</span
+                >
+              </div>
+              <button class="btn-save w-100">💾 Save Schedule</button>
+              <button
+                class="btn btn-outline-secondary rounded-pill fw-700 w-100 mt-2 py-2"
+              >
+                🧹 Clear All
+              </button>
+            </div>
+          </div>
+
+          <div class="tip-card mb-4">
+            <div
+              style="
+                font-weight: 900;
+                font-size: 0.78rem;
+                color: var(--p2);
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                margin-bottom: 14px;
+              "
+            >
+              💡 How it works
+            </div>
+            <div class="tip-row">
+              <span class="tip-icon">🗓️</span
+              ><span>Set your general weekly availability here once.</span>
+            </div>
+            <div class="tip-row">
+              <span class="tip-icon">🚪</span
+              ><span
+                >When invited to a room, your grid is pre-filled
+                automatically.</span
+              >
+            </div>
+            <div class="tip-row">
+              <span class="tip-icon">✏️</span
+              ><span
+                >You can always tweak your availability for a specific
+                event.</span
+              >
+            </div>
+            <div class="tip-row">
+              <span class="tip-icon">🔄</span
+              ><span
+                >Update your schedule any time — it won't affect past
+                submissions.</span
+              >
+            </div>
+          </div>
+
+          <div class="sm-card">
+            <div class="sm-card-header">
+              <i class="bi bi-mortarboard me-2"></i>UWA CAS Import
+            </div>
+            <div class="sm-card-body">
+              <p class="text-muted small fw-700 mb-2">
+                To import from UWA's Class Allocation System:
+              </p>
+              <ol
+                class="small fw-700 text-muted ps-3 mb-3"
+                style="line-height: 2"
+              >
+                <li>
+                  Log in to
+                  <strong style="color: var(--p1)">cas.uwa.edu.au</strong>
+                </li>
+                <li>Go to My Timetable</li>
+                <li>
+                  Export as <strong style="color: var(--p1)">.ics file</strong>
+                </li>
+                <li>
+                  Click
+                  <strong style="color: var(--p1)">Import Timetable</strong>
+                  above
+                </li>
+              </ol>
+              <div
+                style="
+                  background: #fff7ed;
+                  border: 2px solid #fed7aa;
+                  border-radius: 12px;
+                  padding: 10px 14px;
+                  font-size: 0.78rem;
+                  font-weight: 700;
+                  color: #9a3412;
+                "
+              >
+                <i class="bi bi-exclamation-triangle me-1"></i>
+                Your CAS login credentials are never stored by SmartMeet.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <footer class="py-4 text-center">
+      <div class="container">
+        <p class="mb-0 small">
+          © 2026 SmartMeet · CITS3403 Project · University of Western Australia
+        </p>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
**Summary**
Builds on the initial frontend mockup (#3) with improvements to three existing pages and adds a new My Schedule page.

**Changes**

**availability.html**
- Added event meta strip in the banner showing date range, time window and participant count
- Removed t-best tile state (belongs only on results page)
- Added hour separators on the grid for readability
- Added response progress bar showing how many participants have responded
- Replaced small instruction text with a clearer instruction bar

**dashboard.html**
- Added "Rooms You're Invited To" section separate from rooms you created
- Added deadline badges on each room card showing closing date
- Added share button on all room cards
- Added My Schedule link to the sidebar menu

**results.html**
- Added runner-up slots section showing 2nd and 3rd best time options
- Added hour separators on the heatmap grid
- Added remind button for pending participants
- Separated "Back to My Space" button from the main action buttons

**schedule.html (new page)**
- Weekly availability grid (Mon–Sun, 30-minute slots)
- Calendar import section with Google Calendar, Apple Calendar, Microsoft Outlook and UWA CAS
- Save schedule button with last saved indicator
- UWA CAS step-by-step import guide in sidebar

**Notes**
All pages link to style.css from the shared stylesheet PR
Navbar updated across all pages to include My Schedule tab