### PR TITLE
feat(social): friends, notifications, schedule and settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -616,28 +616,255 @@ def remind_participant(code, user_id):
     db.session.commit()
     return redirect(url_for('main.results', code=code, reminded=1))
 
-# TODO: Replace with full friends routes — Person 4 (feature/social)
+# ════════════════════════════════════════════════════════════════
+#  Friends
+# ════════════════════════════════════════════════════════════════
+
 @main.route('/friends')
 @login_required
 def friends():
-    return redirect(url_for('main.index'))
+    accepted = Friendship.query.filter(
+        (Friendship.user1_id == current_user.id) | (Friendship.user2_id == current_user.id),
+        Friendship.status == 'accepted',
+    ).all()
+    pending_received = Friendship.query.filter_by(
+        user2_id=current_user.id, status='pending'
+    ).all()
+    pending_sent = Friendship.query.filter_by(
+        user1_id=current_user.id, status='pending'
+    ).all()
+    return render_template('friends.html',
+                           user=current_user,
+                           friends=accepted,
+                           pending_received=pending_received,
+                           pending_sent=pending_sent)
 
-# TODO: Replace with full notifications routes — Person 4 (feature/social)
+
+@main.route('/friends/add', methods=['POST'])
+@login_required
+def send_friend_request():
+    username = request.form.get('username', '').strip()
+    target   = User.query.filter_by(username=username).first()
+
+    if not target:
+        return redirect(url_for('main.friends', error='User not found.'))
+    if target.id == current_user.id:
+        return redirect(url_for('main.friends', error='You cannot add yourself.'))
+
+    existing = Friendship.query.filter(
+        ((Friendship.user1_id == current_user.id) & (Friendship.user2_id == target.id)) |
+        ((Friendship.user1_id == target.id)       & (Friendship.user2_id == current_user.id))
+    ).first()
+    if existing:
+        return redirect(url_for('main.friends', error='Friend request already exists.'))
+    if not target.allow_friend_requests:
+        return redirect(url_for('main.friends',
+                                error=f'{target.display_name} is not accepting friend requests.'))
+
+    db.session.add(Friendship(
+        user1_id=current_user.id, user2_id=target.id, status='pending'
+    ))
+    if target.notif_friend_requests:
+        db.session.add(Notification(
+            user_id=target.id, type='friend',
+            message=f'{current_user.display_name} sent you a friend request.',
+        ))
+    db.session.commit()
+    return redirect(url_for('main.friends', success=f'Friend request sent to {target.display_name}!'))
+
+
+@main.route('/friends/accept/<int:friendship_id>', methods=['POST'])
+@login_required
+def accept_friend(friendship_id):
+    friendship = Friendship.query.get_or_404(friendship_id)
+    if friendship.user2_id != current_user.id:
+        return redirect(url_for('main.friends'))
+
+    friendship.status = 'accepted'
+    if friendship.sender.notif_friend_requests:
+        db.session.add(Notification(
+            user_id=friendship.user1_id, type='friend',
+            message=f'{current_user.display_name} accepted your friend request!',
+        ))
+    db.session.commit()
+    return redirect(url_for('main.friends'))
+
+
+@main.route('/friends/decline/<int:friendship_id>', methods=['POST'])
+@login_required
+def decline_friend(friendship_id):
+    friendship = Friendship.query.get_or_404(friendship_id)
+    if friendship.user2_id != current_user.id:
+        return redirect(url_for('main.friends'))
+    db.session.delete(friendship)
+    db.session.commit()
+    return redirect(url_for('main.friends'))
+
+
+@main.route('/friends/cancel/<int:friendship_id>', methods=['POST'])
+@login_required
+def cancel_friend_request(friendship_id):
+    friendship = Friendship.query.get_or_404(friendship_id)
+    if friendship.user1_id != current_user.id:
+        return redirect(url_for('main.friends'))
+    db.session.delete(friendship)
+    db.session.commit()
+    return redirect(url_for('main.friends'))
+
+
+@main.route('/friends/remove/<int:friendship_id>', methods=['POST'])
+@login_required
+def remove_friend(friendship_id):
+    friendship = Friendship.query.get_or_404(friendship_id)
+    if friendship.user1_id != current_user.id and friendship.user2_id != current_user.id:
+        return redirect(url_for('main.friends'))
+    db.session.delete(friendship)
+    db.session.commit()
+    return redirect(url_for('main.friends'))
+
+
+@main.route('/users/search')
+@login_required
+def search_users():
+    query = request.args.get('q', '').strip()
+    if len(query) < 2:
+        return jsonify({'users': []})
+    users = User.query.filter(
+        (User.username.ilike(f'%{query}%')) | (User.display_name.ilike(f'%{query}%'))
+    ).filter(User.id != current_user.id).limit(8).all()
+    return jsonify({'users': [
+        {'username': u.username, 'display_name': u.display_name,
+         'avatar': u.avatar, 'public_profile': u.public_profile}
+        for u in users
+    ]})
+
+# ════════════════════════════════════════════════════════════════
+#  Notifications
+# ════════════════════════════════════════════════════════════════
+
 @main.route('/notifications')
 @login_required
 def notifications():
-    return redirect(url_for('main.index'))
+    return render_template('notifications.html', user=current_user)
 
-# TODO: Replace with full schedule routes — Person 4 (feature/social)
-@main.route('/schedule')
+
+@main.route('/notifications/mark-all-read', methods=['POST'])
 @login_required
-def schedule():
-    return redirect(url_for('main.index'))
+def mark_all_read():
+    for notif in current_user.notifications:
+        notif.is_read = True
+    db.session.commit()
+    return redirect(url_for('main.notifications'))
 
-# TODO: Replace with full settings routes — Person 4 (feature/social)
+
+@main.route('/notifications/<int:notif_id>/read', methods=['POST'])
+@login_required
+def mark_read(notif_id):
+    notif = Notification.query.get_or_404(notif_id)
+    if notif.user_id == current_user.id:
+        notif.is_read = True
+        db.session.commit()
+    return redirect(url_for('main.notifications'))
+
+# ════════════════════════════════════════════════════════════════
+#  Schedule
+# ════════════════════════════════════════════════════════════════
+
+@main.route('/schedule')
+@main.route('/schedule/<username>')
+@login_required
+def schedule(username=None):
+    viewed_user = None
+    target_user = current_user
+
+    if username:
+        viewed_user = User.query.filter_by(username=username).first_or_404()
+        target_user = viewed_user
+
+    existing = {
+        f"{e.day}|{e.time_slot}": e.status
+        for e in PersonalSchedule.query.filter_by(user_id=target_user.id).all()
+    }
+
+    return render_template('schedule.html',
+                           user=current_user,
+                           viewed_user=viewed_user,
+                           existing=existing)
+
+
+@main.route('/schedule/save', methods=['POST'])
+@login_required
+def save_schedule():
+    import json
+    entries = json.loads(request.form.get('schedule_data', '[]'))
+
+    PersonalSchedule.query.filter_by(user_id=current_user.id).delete()
+    for entry in entries:
+        db.session.add(PersonalSchedule(
+            user_id=current_user.id,
+            day=entry['day'],
+            time_slot=entry['slot'],
+            status=entry['status'],
+        ))
+
+    db.session.commit()
+    return redirect(url_for('main.schedule', saved=1))
+
+# ════════════════════════════════════════════════════════════════
+#  Settings
+# ════════════════════════════════════════════════════════════════
+
 @main.route('/settings')
 @login_required
 def settings():
+    return render_template('settings.html', user=current_user)
+
+
+@main.route('/settings/save', methods=['POST'])
+@login_required
+def save_profile():
+    current_user.display_name = request.form.get('display_name', '').strip()
+    current_user.bio          = request.form.get('bio', '').strip()
+    current_user.avatar       = request.form.get('avatar', '').strip()
+
+    new_username = request.form.get('username', '').strip()
+    if new_username != current_user.username:
+        if User.query.filter_by(username=new_username).first():
+            return redirect(url_for('main.settings', error='Username already taken'))
+        current_user.username = new_username
+
+    db.session.commit()
+    return redirect(url_for('main.settings', saved=1))
+
+
+@main.route('/settings/notifications', methods=['POST'])
+@login_required
+def save_notification_preferences():
+    current_user.notif_availability    = 'notif_availability'    in request.form
+    current_user.notif_best_time       = 'notif_best_time'       in request.form
+    current_user.notif_room_invites    = 'notif_room_invites'    in request.form
+    current_user.notif_friend_requests = 'notif_friend_requests' in request.form
+    current_user.notif_deadlines       = 'notif_deadlines'       in request.form
+    db.session.commit()
+    return redirect(url_for('main.settings', saved=1))
+
+
+@main.route('/settings/privacy', methods=['POST'])
+@login_required
+def save_privacy_preferences():
+    current_user.allow_friend_requests = 'allow_friend_requests' in request.form
+    current_user.public_profile        = 'public_profile'        in request.form
+    db.session.commit()
+    return redirect(url_for('main.settings', saved=1))
+
+
+@main.route('/settings/delete', methods=['POST'])
+@login_required
+def delete_account():
+    user = current_user._get_current_object()
+    logout_user()
+    db.session.delete(user)
+    db.session.commit()
     return redirect(url_for('main.index'))
 
 

--- a/app/templates/friends.html
+++ b/app/templates/friends.html
@@ -1,0 +1,215 @@
+{% extends 'base_sidebar.html' %}
+{% from '_macros.html' import csrf_input, flash_error, flash_success %}
+
+{% block title %}SmartMeet – Friends{% endblock %}
+{% block sidebar_friends %}active{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+  <div>
+    <p class="section-sub">Social</p>
+    <h2 class="fw-900 mb-0" style="font-size:1.6rem;">👥 Friends</h2>
+  </div>
+</div>
+
+{% if request.args.get('error') %}
+  {{ flash_error(request.args.get('error')) }}
+{% endif %}
+{% if request.args.get('success') %}
+  {{ flash_success('✅ ' + request.args.get('success')) }}
+{% endif %}
+
+{# ── Add a friend ── #}
+<div class="sm-card mb-4" style="overflow:visible;">
+  <div class="sm-card-body">
+    <label class="fw-800 mb-2 field-label">ADD A FRIEND</label>
+    <form method="POST" action="{{ url_for('main.send_friend_request') }}" class="d-flex gap-2" id="addFriendForm">
+      {{ csrf_input() }}
+      <div style="position:relative;flex:1;">
+        <input type="text" name="username" id="friendSearch" class="form-control form-control-purple fw-700"
+          placeholder="Search by username…" autocomplete="off" />
+        <div id="searchDropdown" class="search-dropdown"></div>
+      </div>
+      <button type="submit" class="btn-room px-4" style="white-space:nowrap;">
+        <i class="bi bi-person-plus-fill me-1"></i>Add
+      </button>
+    </form>
+  </div>
+</div>
+
+{# ── Pending requests received ── #}
+{% if pending_received %}
+<div class="section-header mb-3">
+  Pending Requests
+  <span class="badge rounded-pill ms-2" style="background:var(--p4);color:var(--p2);font-size:.75rem;">{{ pending_received | length }}</span>
+</div>
+<div class="row g-3 mb-4">
+  {% for friendship in pending_received %}
+  {% set requester = friendship.sender %}
+  <div class="col-md-6">
+    <div class="friend-card pending">
+      <div class="part-circle" style="background:linear-gradient(135deg,#f472b6,#a78bfa);width:48px;height:48px;font-size:1.4rem;flex-shrink:0;">
+        {{ requester.avatar }}
+      </div>
+      <div class="flex-grow-1">
+        <div class="fw-800">{{ requester.display_name }}</div>
+        <div class="text-muted small">@{{ requester.username }}</div>
+      </div>
+      <div class="d-flex gap-2 flex-wrap align-items-center">
+        {% if requester.public_profile %}
+        <a href="{{ url_for('main.schedule', username=requester.username) }}" class="btn-view-profile">👤 View Profile</a>
+        {% endif %}
+        <form method="POST" action="{{ url_for('main.accept_friend', friendship_id=friendship.id) }}">
+          {{ csrf_input() }}
+          <button type="submit" class="btn btn-sm rounded-pill fw-700" style="background:var(--p2);color:#fff;border:none;padding:4px 14px;">Accept</button>
+        </form>
+        <form method="POST" action="{{ url_for('main.decline_friend', friendship_id=friendship.id) }}">
+          {{ csrf_input() }}
+          <button type="submit" class="btn btn-sm rounded-pill fw-700 btn-muted-sm">Decline</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{# ── Pending requests sent ── #}
+{% if pending_sent %}
+<div class="section-header mb-3">
+  Sent Requests
+  <span class="badge rounded-pill ms-2" style="background:var(--p4);color:var(--p2);font-size:.75rem;">{{ pending_sent | length }}</span>
+</div>
+<div class="row g-3 mb-4">
+  {% for friendship in pending_sent %}
+  {% set recipient = friendship.receiver %}
+  <div class="col-md-6">
+    <div class="friend-card">
+      <div class="part-circle" style="background:linear-gradient(135deg,#22d3ee,#6d28d9);width:48px;height:48px;font-size:1.4rem;flex-shrink:0;">
+        {{ recipient.avatar }}
+      </div>
+      <div class="flex-grow-1">
+        <div class="fw-800">{{ recipient.display_name }}</div>
+        <div class="text-muted small">@{{ recipient.username }} · Pending</div>
+      </div>
+      <div class="d-flex gap-2 align-items-center">
+        {% if recipient.public_profile %}
+        <a href="{{ url_for('main.schedule', username=recipient.username) }}" class="btn-view-profile">👤 View Profile</a>
+        {% endif %}
+        <form method="POST" action="{{ url_for('main.cancel_friend_request', friendship_id=friendship.id) }}">
+          {{ csrf_input() }}
+          <button type="submit" class="btn btn-sm rounded-pill fw-700 btn-muted-sm">Cancel</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+{# ── Friends list ── #}
+<div class="section-header mb-3">
+  Your Friends
+  <span class="badge rounded-pill ms-2" style="background:var(--p4);color:var(--p2);font-size:.75rem;">{{ friends | length }}</span>
+</div>
+
+<div class="mb-3">
+  <input type="text" id="filterFriends" class="form-control form-control-purple fw-700"
+    placeholder="Filter friends…" style="max-width:320px;" />
+</div>
+
+<div class="row g-3" id="friendsList">
+  {% if friends %}
+    {% for friendship in friends %}
+    {% set friend = friendship.receiver if friendship.user1_id == user.id else friendship.sender %}
+    <div class="col-md-6" data-name="{{ friend.display_name | lower }}">
+      <div class="friend-card">
+        <div class="part-circle" style="background:linear-gradient(135deg,#f472b6,#a78bfa);width:48px;height:48px;font-size:1.4rem;flex-shrink:0;">
+          {{ friend.avatar }}
+        </div>
+        <div class="flex-grow-1">
+          <div class="fw-800">{{ friend.display_name }}</div>
+          <div class="text-muted small">@{{ friend.username }}</div>
+        </div>
+        <div class="d-flex flex-row gap-2 align-items-center">
+          <a href="{{ url_for('main.schedule', username=friend.username) }}" class="btn-view-profile">View Profile</a>
+          <form method="POST" action="{{ url_for('main.remove_friend', friendship_id=friendship.id) }}">
+            {{ csrf_input() }}
+            <button type="submit" class="btn btn-sm rounded-pill fw-700 btn-danger-sm">Remove</button>
+          </form>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  {% else %}
+    <div class="col-12">
+      <p class="text-muted fw-700 text-center py-3">No friends yet. Add someone above!</p>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+  // ── Filter friends ──
+  document.getElementById("filterFriends").addEventListener("input", function () {
+    const q = this.value.toLowerCase().trim();
+    document.querySelectorAll("#friendsList .col-md-6").forEach(col => {
+      col.style.display = (col.dataset.name || "").includes(q) ? "" : "none";
+    });
+  });
+
+  // ── Username search dropdown ──
+  const friendSearch       = document.getElementById("friendSearch");
+  const searchDropdown     = document.getElementById("searchDropdown");
+  let selectedFromDropdown = false;
+
+  friendSearch.addEventListener("input", async function () {
+    const q = this.value.trim();
+    selectedFromDropdown = false;
+    if (q.length < 2) { searchDropdown.style.display = "none"; return; }
+    const data = await fetch(`/users/search?q=${encodeURIComponent(q)}`).then(r => r.json());
+    if (!data.users.length) { searchDropdown.style.display = "none"; return; }
+    searchDropdown.innerHTML = data.users.map(u => `
+      <div class="search-result-item" data-username="${u.username}" data-public-profile="${u.public_profile}">
+        <span style="font-size:1.2rem;">${u.avatar}</span>
+        <div>
+          <div style="font-size:.9rem;">${u.display_name}</div>
+          <div style="font-size:.75rem;color:#9ca3af;">@${u.username}</div>
+        </div>
+      </div>
+    `).join("");
+    searchDropdown.style.display = "block";
+
+    searchDropdown.querySelectorAll(".search-result-item").forEach(item => {
+      item.addEventListener("click", () => {
+        friendSearch.value = item.dataset.username;
+        searchDropdown.style.display = "none";
+        selectedFromDropdown = true;
+        document.getElementById("viewProfileBtn")?.remove();
+        if (item.dataset.publicProfile === "true") {
+          const btn = Object.assign(document.createElement("a"), {
+            id: "viewProfileBtn",
+            href: "/schedule/" + item.dataset.username,
+            textContent: "👤 View Profile",
+            className: "btn-view-profile",
+          });
+          document.getElementById("addFriendForm").appendChild(btn);
+        }
+      });
+    });
+  });
+
+  friendSearch.addEventListener("keydown", e => {
+    if (e.key === "Enter" && !selectedFromDropdown) e.preventDefault();
+  });
+
+  document.addEventListener("click", e => {
+    if (!friendSearch.contains(e.target) && !searchDropdown.contains(e.target)) {
+      searchDropdown.style.display = "none";
+    }
+  });
+})();
+</script>
+{% endblock %}

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -1,0 +1,74 @@
+{% extends 'base_sidebar.html' %}
+{% from '_macros.html' import csrf_input %}
+
+{% block title %}SmartMeet – Notifications{% endblock %}
+{% block sidebar_notifications %}active{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+  <div>
+    <p class="section-sub">Activity</p>
+    <h2 class="fw-900 mb-0" style="font-size:1.6rem;">🔔 Notifications</h2>
+  </div>
+  {% set unread_notifs = user.notifications | selectattr('is_read', 'equalto', false) | list %}
+  {% if unread_notifs %}
+  <form method="POST" action="{{ url_for('main.mark_all_read') }}">
+    {{ csrf_input() }}
+    <button type="submit" class="btn btn-outline-secondary rounded-pill fw-700 px-4" style="font-size:.85rem;">
+      <i class="bi bi-check-all me-1"></i>Mark all as read
+    </button>
+  </form>
+  {% endif %}
+</div>
+
+<div id="notifList" class="d-flex flex-column gap-3">
+  {% set notifications = user.notifications | sort(attribute='created_at', reverse=True) %}
+  {% if notifications %}
+    {% for notif in notifications %}
+    <div class="notif-item {% if not notif.is_read %}unread{% endif %}">
+      <div class="notif-icon" style="background:linear-gradient(135deg,#a78bfa,#ec4899);">
+        {% if notif.type == 'availability' %}🗓️
+        {% elif notif.type == 'confirmed' %}✅
+        {% elif notif.type == 'best_time' %}🏆
+        {% elif notif.type == 'invite' %}📨
+        {% elif notif.type == 'friend' %}👥
+        {% else %}🔔
+        {% endif %}
+      </div>
+      <div class="flex-grow-1">
+        <div>{{ notif.message }}</div>
+        <div class="notif-meta">
+          <i class="bi bi-clock me-1"></i>
+          <span class="notif-time" data-utc="{{ notif.created_at.strftime('%Y-%m-%dT%H:%M:%S') }}Z"></span>
+        </div>
+      </div>
+      {% if not notif.is_read %}
+      <form method="POST" action="{{ url_for('main.mark_read', notif_id=notif.id) }}">
+        {{ csrf_input() }}
+        <button type="submit" class="notif-action" style="background:none;border:none;cursor:pointer;">Mark read</button>
+      </form>
+      {% endif %}
+    </div>
+    {% endfor %}
+  {% else %}
+    <div class="text-center py-5">
+      <div style="font-size:3rem;margin-bottom:12px;">🎉</div>
+      <div class="fw-800" style="font-size:1.1rem;color:var(--p2);">You're all caught up!</div>
+      <div class="text-muted small mt-1">No notifications yet.</div>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  document.querySelectorAll('.notif-time').forEach(el => {
+    const date = new Date(el.dataset.utc);
+    el.textContent = date.toLocaleDateString('en-AU', {
+      day: '2-digit', month: 'short', year: 'numeric'
+    }) + ' · ' + date.toLocaleTimeString('en-AU', {
+      hour: '2-digit', minute: '2-digit', hour12: true
+    });
+  });
+</script>
+{% endblock %}

--- a/app/templates/schedule.html
+++ b/app/templates/schedule.html
@@ -1,0 +1,264 @@
+{% extends 'base.html' %}
+{% from '_macros.html' import csrf_input %}
+
+{% block title %}SmartMeet – {% if viewed_user %}{{ viewed_user.display_name }}'s Schedule{% else %}My Schedule{% endif %}{% endblock %}
+{% block nav_schedule %}{% if not viewed_user %}active{% endif %}{% endblock %}
+
+{% block body %}
+
+  <div class="page-header text-center">
+    <div class="container position-relative">
+      <div class="page-header-icon">🗓️</div>
+      {% if viewed_user %}
+        <h2 class="pixel-title mb-2">{{ viewed_user.display_name }}'s Schedule</h2>
+        <p style="opacity:0.8;font-size:0.95rem;max-width:520px;margin:0 auto;">
+          Viewing {{ viewed_user.display_name }}'s weekly availability.
+        </p>
+      {% else %}
+        <h2 class="pixel-title mb-2">My Schedule</h2>
+        <p style="opacity:0.8;font-size:0.95rem;max-width:520px;margin:0 auto;">
+          Set your general weekly availability. SmartMeet will use this to pre-fill your responses.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+
+  <div class="container py-5" style="max-width:1000px;">
+    <div class="row g-4">
+
+      {# ── Schedule grid ── #}
+      <div class="col-lg-8">
+
+        {% if viewed_user %}
+        <div class="sm-card mb-4">
+          <div class="sm-card-body d-flex align-items-center gap-3">
+            <div class="mini-participant-avatar" style="width:56px;height:56px;font-size:1.8rem;flex-shrink:0;">
+              {{ viewed_user.avatar }}
+            </div>
+            <div>
+              <div class="fw-900 fs-5">{{ viewed_user.display_name }}</div>
+              <div class="text-muted small fw-600">@{{ viewed_user.username }}</div>
+              {% if viewed_user.bio %}
+              <div class="text-muted small fst-italic mt-1">"{{ viewed_user.bio }}"</div>
+              {% endif %}
+            </div>
+            <div class="ms-auto">
+              <div class="d-inline-block px-3 py-1 rounded-pill level-badge">
+                ✨ {{ viewed_user.level_title }}
+              </div>
+            </div>
+          </div>
+        </div>
+        {% endif %}
+
+        <div class="sm-card">
+          <div class="sm-card-header" style="justify-content:space-between;flex-wrap:wrap;gap:10px;">
+            <span><i class="bi bi-grid-3x3-gap me-2"></i>Weekly Availability</span>
+            <div class="d-flex gap-3 flex-wrap align-items-center">
+              <span class="legend-chip"><span class="legend-swatch t-free"></span>Free</span>
+              <span class="legend-chip"><span class="legend-swatch t-maybe"></span>Maybe</span>
+              <span class="legend-chip"><span class="legend-swatch t-busy"></span>Busy</span>
+              <span class="legend-chip"><span class="legend-swatch t-empty"></span>Not set</span>
+            </div>
+          </div>
+          <div class="sm-card-body">
+            {% if not viewed_user %}
+            <div class="time-filter mb-3">
+              <span>Show hours:</span>
+              <select id="startTimeSelect">
+                <option>6:00 AM</option>
+                <option selected>8:00 AM</option>
+                <option>9:00 AM</option>
+              </select>
+              <span>to</span>
+              <select id="endTimeSelect">
+                <option>6:00 PM</option>
+                <option selected>8:00 PM</option>
+                <option>10:00 PM</option>
+              </select>
+              <span class="ms-auto text-muted" style="font-size:.75rem;">Click to cycle: Empty → Free → Maybe → Busy → Empty</span>
+            </div>
+            {% endif %}
+
+            <div class="grid-outer">
+              <table class="av-table" id="schedGrid">
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>Mon</th><th>Tue</th><th>Wed</th><th>Thu</th><th>Fri</th>
+                    <th style="color:var(--pink);">Sat</th>
+                    <th style="color:var(--pink);">Sun</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% set days  = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'] %}
+                  {% set slots = [
+                    '8:00 AM','8:30 AM','9:00 AM','9:30 AM','10:00 AM','10:30 AM',
+                    '11:00 AM','11:30 AM','12:00 PM','12:30 PM','1:00 PM','1:30 PM',
+                    '2:00 PM','2:30 PM','3:00 PM','3:30 PM','4:00 PM','4:30 PM',
+                    '5:00 PM','5:30 PM','6:00 PM','6:30 PM','7:00 PM','7:30 PM'
+                  ] %}
+                  {% for slot in slots %}
+                  <tr class="{{ 'hour-start' if ':00 ' in slot else '' }}">
+                    <td class="time-lbl">{{ slot }}</td>
+                    {% for day in days %}
+                      {% set status = existing.get(day + '|' + slot, 'empty') %}
+                      <td class="tile t-{{ status }}" data-day="{{ day }}" data-slot="{{ slot }}"
+                        {% if viewed_user %}style="cursor:default;"{% endif %}></td>
+                    {% endfor %}
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {# ── Sidebar ── #}
+      <div class="col-lg-4">
+        {% if not viewed_user %}
+        <div class="sm-card mb-4">
+          <div class="sm-card-header"><i class="bi bi-floppy me-2"></i>Save Schedule</div>
+          <div class="sm-card-body">
+            <p class="text-muted small fw-700 mb-3">
+              Your schedule is used to pre-fill your availability when you're invited to a room.
+            </p>
+            {% if request.args.get('saved') %}
+            <div class="alert-success mb-3">✅ Schedule saved!</div>
+            {% endif %}
+            <form method="POST" action="{{ url_for('main.save_schedule') }}" id="scheduleForm">
+              {{ csrf_input() }}
+              <input type="hidden" name="schedule_data" id="scheduleData" />
+              <button type="submit" class="btn-save w-100" id="saveBtn">💾 Save Schedule</button>
+            </form>
+            <button class="btn btn-outline-secondary rounded-pill fw-700 w-100 mt-2 py-2" id="clearAllBtn">
+              🧹 Clear All
+            </button>
+          </div>
+        </div>
+        {% else %}
+        <div class="sm-card mb-4">
+          <div class="sm-card-body d-flex flex-column gap-2">
+            {% set already_friends = namespace(value=False) %}
+            {% for f in current_user.friendships_sent %}
+              {% if f.user2_id == viewed_user.id %}{% set already_friends.value = True %}{% endif %}
+            {% endfor %}
+            {% for f in current_user.friendships_recv %}
+              {% if f.user1_id == viewed_user.id %}{% set already_friends.value = True %}{% endif %}
+            {% endfor %}
+            {% if not already_friends.value %}
+            <form method="POST" action="{{ url_for('main.send_friend_request') }}">
+              {{ csrf_input() }}
+              <input type="hidden" name="username" value="{{ viewed_user.username }}" />
+              <button type="submit" class="btn-room w-100 py-2">
+                <i class="bi bi-person-plus-fill me-1"></i>Add Friend
+              </button>
+            </form>
+            {% endif %}
+            <a href="{{ url_for('main.friends') }}" class="btn-room w-100 text-center py-2 d-block">
+              ← Back to Friends
+            </a>
+          </div>
+        </div>
+        {% endif %}
+
+        <div class="tip-card mb-4">
+          <div class="fw-900 mb-3 field-label">💡 How it works</div>
+          <div class="tip-row"><span class="tip-icon">🗓️</span><span>Set your general weekly availability here once.</span></div>
+          <div class="tip-row"><span class="tip-icon">🪄</span><span>When invited to a room, you can pre-fill the grid with your saved schedule.</span></div>
+          <div class="tip-row"><span class="tip-icon">✏️</span><span>You can always tweak your availability for a specific event.</span></div>
+          <div class="tip-row"><span class="tip-icon">🔄</span><span>Update your schedule any time, it won't affect past submissions.</span></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+  const STATES = ["t-empty", "t-free", "t-maybe", "t-busy"];
+  const tiles  = document.querySelectorAll("#schedGrid td.tile");
+
+  {% if not viewed_user %}
+  let isDragging      = false;
+  let dragTargetState = null;
+
+  function nextState(tile) {
+    const cur = STATES.find(s => tile.classList.contains(s)) || "t-empty";
+    return STATES[(STATES.indexOf(cur) + 1) % STATES.length];
+  }
+
+  function paintTile(tile, state) {
+    tile.classList.remove(...STATES);
+    tile.classList.add(state);
+  }
+
+  tiles.forEach(tile => {
+    tile.addEventListener("mousedown", e => {
+      e.preventDefault();
+      isDragging = true;
+      dragTargetState = nextState(tile);
+      paintTile(tile, dragTargetState);
+    });
+    tile.addEventListener("mouseenter", () => {
+      if (isDragging) paintTile(tile, dragTargetState);
+    });
+    tile.addEventListener("touchstart", e => {
+      e.preventDefault();
+      isDragging = true;
+      dragTargetState = nextState(tile);
+      paintTile(tile, dragTargetState);
+    }, { passive: false });
+    tile.addEventListener("touchmove", e => {
+      e.preventDefault();
+      const el = document.elementFromPoint(e.touches[0].clientX, e.touches[0].clientY);
+      if (el && el.classList.contains("tile")) paintTile(el, dragTargetState);
+    }, { passive: false });
+  });
+
+  document.addEventListener("mouseup",  () => { isDragging = false; dragTargetState = null; });
+  document.addEventListener("touchend", () => { isDragging = false; dragTargetState = null; });
+
+  document.getElementById("clearAllBtn").addEventListener("click", () => {
+    tiles.forEach(tile => { tile.classList.remove(...STATES); tile.classList.add("t-empty"); });
+  });
+
+  // Time range filter
+  const timeToHour  = { "6:00 AM":6, "8:00 AM":8, "9:00 AM":9, "6:00 PM":18, "8:00 PM":20, "10:00 PM":22 };
+  const startSelect = document.getElementById("startTimeSelect");
+  const endSelect   = document.getElementById("endTimeSelect");
+
+  function applyTimeFilter() {
+    const startHour = timeToHour[startSelect.value] ?? 0;
+    const endHour   = timeToHour[endSelect.value]   ?? 24;
+    document.querySelectorAll("#schedGrid tbody tr").forEach(row => {
+      const label = row.querySelector(".time-lbl");
+      if (!label) return;
+      const [time, period] = label.textContent.trim().split(" ");
+      let h = parseInt(time.split(":")[0]);
+      if (period === "PM" && h !== 12) h += 12;
+      if (period === "AM" && h === 12) h = 0;
+      row.style.display = h >= startHour && h < endHour ? "" : "none";
+    });
+  }
+  startSelect.addEventListener("change", applyTimeFilter);
+  endSelect.addEventListener("change",   applyTimeFilter);
+  applyTimeFilter();
+
+  // Serialize schedule on submit
+  document.getElementById("scheduleForm").addEventListener("submit", function () {
+    const data = [];
+    tiles.forEach(tile => {
+      const state = STATES.find(s => tile.classList.contains(s)) || "t-empty";
+      if (state !== "t-empty") data.push({ day: tile.dataset.day, slot: tile.dataset.slot, status: state.replace("t-", "") });
+    });
+    document.getElementById("scheduleData").value = JSON.stringify(data);
+  });
+  {% endif %}
+})();
+</script>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,0 +1,182 @@
+{% extends 'base_sidebar.html' %}
+{% from '_macros.html' import csrf_input, flash_success %}
+
+{% block title %}SmartMeet – Settings{% endblock %}
+{% block sidebar_settings %}active{% endblock %}
+
+{% block modals %}
+<div id="deleteModal" class="sm-modal-overlay" style="display:none;">
+  <div class="sm-modal-box">
+    <div class="sm-modal-icon">⚠️</div>
+    <div class="sm-modal-title danger">Delete Account?</div>
+    <p class="sm-modal-body">
+      This will permanently delete your account and all your rooms.
+      <strong style="color:#dc2626;">This cannot be undone.</strong>
+    </p>
+    <div class="d-flex gap-3 justify-content-center">
+      <button id="cancelDeleteBtn" class="btn btn-secondary rounded-pill fw-800 px-4">Cancel</button>
+      <form method="POST" action="{{ url_for('main.delete_account') }}">
+        {{ csrf_input() }}
+        <button type="submit" class="btn btn-danger rounded-pill fw-800 px-4">Yes, Delete</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="mb-4">
+  <p class="section-sub">Preferences</p>
+  <h2 class="fw-900 mb-0" style="font-size:1.6rem;">⚙️ Settings</h2>
+</div>
+
+{% if request.args.get('saved') %}
+  {{ flash_success('✅ Profile saved successfully!') }}
+{% endif %}
+
+{# ── Profile ── #}
+<div class="sm-card mb-4">
+  <div class="sm-card-header">👤 Profile</div>
+  <div class="sm-card-body">
+    <form method="POST" action="{{ url_for('main.save_profile') }}">
+      {{ csrf_input() }}
+      <input type="hidden" name="avatar" id="avatarInput" value="{{ user.avatar }}" />
+      <div class="row g-3">
+        <div class="col-sm-6">
+          <label class="form-label field-label">Display Name</label>
+          <input type="text" name="display_name" class="form-control form-control-purple fw-700" value="{{ user.display_name }}" />
+        </div>
+        <div class="col-sm-6">
+          <label class="form-label field-label">Username</label>
+          <input type="text" name="username" class="form-control form-control-purple fw-700" value="{{ user.username }}" />
+        </div>
+        <div class="col-sm-6">
+          <label class="form-label field-label">Email</label>
+          <div class="form-control fw-700" style="border:2px solid #e5e7eb;border-radius:12px;background:#f9fafb;color:var(--muted);">{{ user.email }}</div>
+          <div class="text-muted mt-1" style="font-size:.75rem;font-weight:700;">Email cannot be changed.</div>
+        </div>
+        <div class="col-sm-6">
+          <label class="form-label field-label">Avatar</label>
+          <div class="d-flex gap-2 flex-wrap mt-1">
+            {% for emoji in ['🐱','🦊','🐻','🐼','🐶','🐸','🦅','🧊','🎯','🦁','🐮','🐷'] %}
+            <span class="avatar-pick {% if user.avatar == emoji %}selected{% endif %}" data-emoji="{{ emoji }}">{{ emoji }}</span>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="col-12">
+          <label class="form-label field-label">Bio</label>
+          <input type="text" name="bio" class="form-control form-control-purple fw-700"
+            value="{{ user.bio or '' }}" placeholder="Tell us a bit about yourself..." />
+        </div>
+      </div>
+      <div class="mt-3">
+        <button type="submit" class="btn-room px-4">💾 Save Profile</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{# ── Notifications ── #}
+<div class="sm-card mb-4">
+  <div class="sm-card-header">🔔 Notifications</div>
+  <div class="sm-card-body">
+    <form method="POST" action="{{ url_for('main.save_notification_preferences') }}">
+      {{ csrf_input() }}
+      <div class="d-flex flex-column gap-3">
+        {% set notif_items = [
+          ('notif_availability',    user.notif_availability,    'Availability submitted',  'When someone responds to your room'),
+          ('notif_best_time',       user.notif_best_time,       'Best time found',         'When a perfect slot is found for your room'),
+          ('notif_room_invites',    user.notif_room_invites,    'Room invites',            'When a friend invites you to a room'),
+          ('notif_friend_requests', user.notif_friend_requests, 'Friend requests',         'When someone sends you a friend request'),
+          ('notif_deadlines',       user.notif_deadlines,       'Deadline reminders',      'Reminder before a room deadline closes'),
+        ] %}
+        {% for name, checked, label, sublabel in notif_items %}
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="fw-800">{{ label }}</div>
+            <div class="text-muted small">{{ sublabel }}</div>
+          </div>
+          <div class="form-check form-switch mb-0">
+            <input class="form-check-input" type="checkbox" name="{{ name }}" {% if checked %}checked{% endif %} style="width:2.5rem;height:1.3rem;cursor:pointer;" />
+          </div>
+        </div>
+        {% if not loop.last %}<hr class="my-0" style="border-color:#ede9fe;" />{% endif %}
+        {% endfor %}
+      </div>
+      <div class="mt-3">
+        <button type="submit" class="btn-room px-4">💾 Save Notification Settings</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{# ── Privacy ── #}
+<div class="sm-card mb-4">
+  <div class="sm-card-header">🔒 Privacy</div>
+  <div class="sm-card-body">
+    <form method="POST" action="{{ url_for('main.save_privacy_preferences') }}">
+      {{ csrf_input() }}
+      <div class="d-flex flex-column gap-3">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="fw-800">Allow friend requests</div>
+            <div class="text-muted small">Anyone can send you a friend request</div>
+          </div>
+          <div class="form-check form-switch mb-0">
+            <input class="form-check-input" type="checkbox" name="allow_friend_requests" {% if user.allow_friend_requests %}checked{% endif %} style="width:2.5rem;height:1.3rem;cursor:pointer;" />
+          </div>
+        </div>
+        <hr class="my-0" style="border-color:#ede9fe;" />
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div class="fw-800">Public profile</div>
+            <div class="text-muted small">Your profile is visible to non-friends</div>
+          </div>
+          <div class="form-check form-switch mb-0">
+            <input class="form-check-input" type="checkbox" name="public_profile" {% if user.public_profile %}checked{% endif %} style="width:2.5rem;height:1.3rem;cursor:pointer;" />
+          </div>
+        </div>
+      </div>
+      <div class="mt-3">
+        <button type="submit" class="btn-room px-4">💾 Save Privacy Settings</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+{# ── Danger zone ── #}
+<div class="sm-card" style="border:2px solid #fca5a5;">
+  <div class="sm-card-header" style="color:#dc2626;">⚠️ Danger Zone</div>
+  <div class="sm-card-body">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-3">
+      <div>
+        <div class="fw-800">Delete Account</div>
+        <div class="text-muted small">Permanently delete your account and all your rooms. This cannot be undone.</div>
+      </div>
+      <button id="deleteAccountBtn" class="btn btn-outline-danger rounded-pill fw-700 px-4">
+        <i class="bi bi-trash me-1"></i>Delete Account
+      </button>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+(function () {
+  document.querySelectorAll(".avatar-pick").forEach(avatar => {
+    avatar.addEventListener("click", function () {
+      document.querySelectorAll(".avatar-pick").forEach(a => a.classList.remove("selected"));
+      this.classList.add("selected");
+      document.getElementById("avatarInput").value         = this.dataset.emoji;
+      document.getElementById("sidebarAvatar").textContent = this.dataset.emoji;
+    });
+  });
+
+  const deleteModal = document.getElementById("deleteModal");
+  document.getElementById("deleteAccountBtn").addEventListener("click", () => deleteModal.style.display = "flex");
+  document.getElementById("cancelDeleteBtn").addEventListener("click",  () => deleteModal.style.display = "none");
+  deleteModal.addEventListener("click", e => { if (e.target === deleteModal) deleteModal.style.display = "none"; });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
Resolves the feature/social tasks. Replaces all 4 stub routes and adds the corresponding Jinja2 templates.

## Changes

### `routes.py`
- **Friends**: list friends, pending received/sent requests, send/accept/decline/cancel/remove, user search endpoint (`/users/search`)
- **Notifications**: view feed, mark one as read, mark all as read
- **Schedule**: view own grid, view a friend's grid (`/schedule/<username>`), save schedule
- **Settings**: save profile, save notification preferences, save privacy preferences, delete account

### New templates
- `friends.html` — friends list, pending requests, sent requests, username search with autocomplete dropdown
- `notifications.html` — activity feed sorted by date, mark as read, empty state
- `schedule.html` — weekly tile grid (own + read-only friend view), time range filter, save/clear
- `settings.html` — profile editor, notification toggles, privacy toggles, custom delete confirmation modal

## Notes
- All stub `TODO` comments for feature/social are now removed
- No stub routes remain after this merge — application is fully functional