### PR TITLE
fix: limit notifications query and clamp room deadline

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -274,6 +274,10 @@ def create_event():
         deadline_str = request.form.get('deadline')
         deadline     = (datetime.strptime(deadline_str, '%Y-%m-%d').date()
                         if deadline_str else None)
+        date_from_d  = datetime.strptime(date_from, '%Y-%m-%d').date()
+        date_to_d    = datetime.strptime(date_to,   '%Y-%m-%d').date()
+        if deadline and not (date_from_d <= deadline <= date_to_d):
+            deadline = date_to_d
 
         selected_dates = request.form.get('selectedDates', '')
         if not selected_dates:
@@ -288,8 +292,8 @@ def create_event():
         room = Room(
             title          = title,
             description    = description,
-            date_from      = datetime.strptime(date_from, '%Y-%m-%d').date(),
-            date_to        = datetime.strptime(date_to,   '%Y-%m-%d').date(),
+            date_from      = date_from_d,
+            date_to        = date_to_d,
             time_start     = time_start,
             time_end       = time_end,
             duration       = duration,
@@ -745,7 +749,12 @@ def search_users():
 @main.route('/notifications')
 @login_required
 def notifications():
-    return render_template('notifications.html', user=current_user)
+    notifications = (Notification.query
+                     .filter_by(user_id=current_user.id)
+                     .order_by(Notification.created_at.desc())
+                     .limit(50)
+                     .all())
+    return render_template('notifications.html', user=current_user, notifications=notifications)
 
 
 @main.route('/notifications/mark-all-read', methods=['POST'])

--- a/app/templates/create_event.html
+++ b/app/templates/create_event.html
@@ -329,6 +329,12 @@
       : `⏱ ${durationEl.value} slots`;
   }
 
+  function updateDeadlineBounds() {
+    const deadlineEl = document.getElementById("deadline");
+    if (dateFromEl.value) deadlineEl.min = dateFromEl.value;
+    if (dateToEl.value)   deadlineEl.max = dateToEl.value;
+  }
+
   function goToStep(n) {
     const current = [1,2,3].find(i => document.getElementById("step"+i).classList.contains("active")) || 1;
     if (n > current) {
@@ -370,8 +376,8 @@
   roomNameEl.addEventListener("input",   updatePreview);
   roomDescEl.addEventListener("input",   updatePreview);
   orgNameEl.addEventListener("input",    updatePreview);
-  dateFromEl.addEventListener("change",  () => { excludedDates.clear(); updateDateTiles(); updateTimePreview(); updatePreview(); });
-  dateToEl.addEventListener("change",    () => { excludedDates.clear(); updateDateTiles(); updateTimePreview(); updatePreview(); });
+  dateFromEl.addEventListener("change",  () => { excludedDates.clear(); updateDateTiles(); updateTimePreview(); updatePreview(); updateDeadlineBounds(); });
+  dateToEl.addEventListener("change",    () => { excludedDates.clear(); updateDateTiles(); updateTimePreview(); updatePreview(); updateDeadlineBounds(); });
   timeStartEl.addEventListener("change", () => { updateTimePreview(); updatePreview(); });
   timeEndEl.addEventListener("change",   () => { updateTimePreview(); updatePreview(); });
   durationEl.addEventListener("change",  () => { updateTimePreview(); updatePreview(); });
@@ -379,6 +385,7 @@
   updatePreview();
   updateDateTiles();
   updateTimePreview();
+  updateDeadlineBounds();
 })();
 </script>
 {% endblock %}

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -10,7 +10,7 @@
     <p class="section-sub">Activity</p>
     <h2 class="fw-900 mb-0" style="font-size:1.6rem;">🔔 Notifications</h2>
   </div>
-  {% set unread_notifs = user.notifications | selectattr('is_read', 'equalto', false) | list %}
+  {% set unread_notifs = notifications | selectattr('is_read', 'equalto', false) | list %}
   {% if unread_notifs %}
   <form method="POST" action="{{ url_for('main.mark_all_read') }}">
     {{ csrf_input() }}
@@ -22,7 +22,6 @@
 </div>
 
 <div id="notifList" class="d-flex flex-column gap-3">
-  {% set notifications = user.notifications | sort(attribute='created_at', reverse=True) %}
   {% if notifications %}
     {% for notif in notifications %}
     <div class="notif-item {% if not notif.is_read %}unread{% endif %}">


### PR DESCRIPTION
Closes #48
Closes #49

## Changes

### fix #48 — Limit notifications query
- Moved sorting and limiting into the route: ordered by `created_at DESC`, limited to 50
- Template now uses the passed `notifications` variable instead of iterating `user.notifications` directly

### fix #49 — Validate meeting deadline range
- Added backend validation in `create_event`: if the submitted deadline falls outside `date_from`–`date_to`, it is clamped to `date_to`
- Reuses the already-parsed `date_from_d` / `date_to_d` objects to avoid redundant parsing