### PR TITLE
refactor: accept config parameter in create_app and add TestConfig

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,9 +13,9 @@ mail = Mail()
 migrate = Migrate()
 login_manager.login_view = 'main.login'
 
-def create_app():
+def create_app(config=Config):
     app = Flask(__name__)
-    app.config.from_object(Config)
+    app.config.from_object(config)
 
     db.init_app(app)
     login_manager.init_app(app)

--- a/config.py
+++ b/config.py
@@ -13,3 +13,9 @@ class Config:
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
     MAIL_DEFAULT_SENDER = os.environ.get('MAIL_USERNAME')
+
+class TestConfig(Config):
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    TESTING = True
+    WTF_CSRF_ENABLED = False   # disables CSRF so test form submissions work
+    MAIL_SUPPRESS_SEND = True  # stops emails actually sending during tests


### PR DESCRIPTION
## Summary

Refactors `create_app()` to accept a config parameter and adds `TestConfig` to `config.py`.

## Changes

- `app/__init__.py` — `create_app` now accepts a config parameter with `Config` as the default
- `config.py` — adds `TestConfig` with in-memory database, CSRF disabled and mail suppressed

## Notes
- No existing functionality is affected since `config=Config` is the default
- Closes #53 